### PR TITLE
Build both ipk and apk packages for OpenWrt 24.10+

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,6 +3,8 @@ name: Build Release Packages
 on:
   release:
     types: [published]
+  pull_request:
+    types: [labeled, synchronize]
 
 permissions:
   contents: write
@@ -10,6 +12,7 @@ permissions:
 jobs:
   build:
     name: Build ${{ matrix.target }}
+    if: github.event_name == 'release' || github.event.label.name == 'run-build' || (github.event_name == 'pull_request' && github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-build'))
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -76,7 +79,11 @@ jobs:
 
       - name: Copy package files
         run: |
-          VERSION=${GITHUB_REF#refs/tags/}
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="0.0.0-pr${{ github.event.pull_request.number }}"
+          fi
           mkdir -p ${{ matrix.sdk_name }}/package/moci
           sed "s/PKG_VERSION:=.*/PKG_VERSION:=$VERSION/" Makefile > ${{ matrix.sdk_name }}/package/moci/Makefile
           cp -r dist ${{ matrix.sdk_name }}/package/moci/
@@ -108,7 +115,11 @@ jobs:
             echo "Error: ipk package not found!"
             exit 1
           fi
-          VERSION=${GITHUB_REF#refs/tags/}
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="0.0.0-pr${{ github.event.pull_request.number }}"
+          fi
           ARCH_SUFFIX="${{ matrix.arch }}"
           NEW_NAME="moci_${VERSION}-r1_${ARCH_SUFFIX}.ipk"
           mv "$IPK_FILE" "/tmp/$NEW_NAME"
@@ -136,7 +147,11 @@ jobs:
             echo "found=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          VERSION=${GITHUB_REF#refs/tags/}
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="0.0.0-pr${{ github.event.pull_request.number }}"
+          fi
           ARCH_SUFFIX="${{ matrix.arch }}"
           NEW_NAME="moci_${VERSION}-r1_${ARCH_SUFFIX}.apk"
           mv "$APK_FILE" "/tmp/$NEW_NAME"
@@ -144,8 +159,18 @@ jobs:
           echo "found=true" >> $GITHUB_OUTPUT
 
       - name: Upload to release
+        if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
           files: |
+            /tmp/${{ steps.find_ipk.outputs.package_name }}
+            /tmp/${{ steps.find_apk.outputs.package_name }}
+
+      - name: Upload build artifacts
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: moci-${{ matrix.arch }}
+          path: |
             /tmp/${{ steps.find_ipk.outputs.package_name }}
             /tmp/${{ steps.find_apk.outputs.package_name }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -158,19 +158,28 @@ jobs:
           echo "package_name=$NEW_NAME" >> $GITHUB_OUTPUT
           echo "found=true" >> $GITHUB_OUTPUT
 
-      - name: Upload to release
+      - name: Upload ipk to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            /tmp/${{ steps.find_ipk.outputs.package_name }}
-            /tmp/${{ steps.find_apk.outputs.package_name }}
+          files: /tmp/${{ steps.find_ipk.outputs.package_name }}
 
-      - name: Upload build artifacts
+      - name: Upload apk to release
+        if: github.event_name == 'release' && steps.find_apk.outputs.found == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: /tmp/${{ steps.find_apk.outputs.package_name }}
+
+      - name: Upload ipk artifact
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v4
         with:
-          name: moci-${{ matrix.arch }}
-          path: |
-            /tmp/${{ steps.find_ipk.outputs.package_name }}
-            /tmp/${{ steps.find_apk.outputs.package_name }}
+          name: moci-ipk-${{ matrix.arch }}
+          path: /tmp/${{ steps.find_ipk.outputs.package_name }}
+
+      - name: Upload apk artifact
+        if: github.event_name != 'release' && steps.find_apk.outputs.found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: moci-apk-${{ matrix.arch }}
+          path: /tmp/${{ steps.find_apk.outputs.package_name }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,8 +10,8 @@ permissions:
   contents: write
 
 jobs:
-  build:
-    name: Build ${{ matrix.target }}
+  build-ipk:
+    name: Build ipk ${{ matrix.arch }}
     if: github.event_name == 'release' || github.event.label.name == 'run-build' || (github.event_name == 'pull_request' && github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-build'))
     runs-on: ubuntu-latest
     strategy:
@@ -62,20 +62,12 @@ jobs:
       - name: Build minified assets
         run: pnpm run build
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y zstd
-
-      - name: Download SDK
+      - name: Download and extract SDK
         run: |
           SDK_URL="https://downloads.openwrt.org/releases/24.10.5/targets/${{ matrix.target }}/${{ matrix.sdk_name }}.tar.zst"
-          echo "Downloading SDK from: $SDK_URL"
           curl -L -o sdk.tar.zst "$SDK_URL"
-
-      - name: Extract SDK
-        run: |
           tar --use-compress-program=unzstd -xf sdk.tar.zst
+          rm sdk.tar.zst
 
       - name: Copy package files
         run: |
@@ -96,17 +88,13 @@ jobs:
           ./scripts/feeds update -a
           ./scripts/feeds install -a
 
-      - name: Configure SDK (ipk)
-        working-directory: ${{ matrix.sdk_name }}
-        run: |
-          make defconfig
-
       - name: Build ipk package
         working-directory: ${{ matrix.sdk_name }}
         run: |
+          make defconfig
           make package/moci/compile V=s
 
-      - name: Find ipk package
+      - name: Find and rename ipk
         id: find_ipk
         working-directory: ${{ matrix.sdk_name }}
         run: |
@@ -120,65 +108,133 @@ jobs:
           else
             VERSION="0.0.0-pr${{ github.event.pull_request.number }}"
           fi
-          ARCH_SUFFIX="${{ matrix.arch }}"
-          NEW_NAME="moci_${VERSION}-r1_${ARCH_SUFFIX}.ipk"
+          NEW_NAME="moci_${VERSION}-r1_${{ matrix.arch }}.ipk"
           mv "$IPK_FILE" "/tmp/$NEW_NAME"
           echo "package_name=$NEW_NAME" >> $GITHUB_OUTPUT
 
-      - name: Configure SDK (apk)
-        working-directory: ${{ matrix.sdk_name }}
-        run: |
-          echo "CONFIG_USE_APK=y" >> .config
-          make defconfig
-
-      - name: Build apk package
-        working-directory: ${{ matrix.sdk_name }}
-        run: |
-          make package/moci/clean V=s
-          make package/moci/compile V=s
-
-      - name: Find apk package
-        id: find_apk
-        working-directory: ${{ matrix.sdk_name }}
-        run: |
-          APK_FILE=$(find bin/packages -name "moci*.apk" | head -n 1)
-          if [ -z "$APK_FILE" ]; then
-            echo "Warning: apk package not found, skipping"
-            echo "found=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          if [ "${{ github.event_name }}" = "release" ]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          else
-            VERSION="0.0.0-pr${{ github.event.pull_request.number }}"
-          fi
-          ARCH_SUFFIX="${{ matrix.arch }}"
-          NEW_NAME="moci_${VERSION}-r1_${ARCH_SUFFIX}.apk"
-          mv "$APK_FILE" "/tmp/$NEW_NAME"
-          echo "package_name=$NEW_NAME" >> $GITHUB_OUTPUT
-          echo "found=true" >> $GITHUB_OUTPUT
-
-      - name: Upload ipk to release
+      - name: Upload to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
           files: /tmp/${{ steps.find_ipk.outputs.package_name }}
 
-      - name: Upload apk to release
-        if: github.event_name == 'release' && steps.find_apk.outputs.found == 'true'
-        uses: softprops/action-gh-release@v2
-        with:
-          files: /tmp/${{ steps.find_apk.outputs.package_name }}
-
-      - name: Upload ipk artifact
+      - name: Upload artifact
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v4
         with:
           name: moci-ipk-${{ matrix.arch }}
           path: /tmp/${{ steps.find_ipk.outputs.package_name }}
 
-      - name: Upload apk artifact
-        if: github.event_name != 'release' && steps.find_apk.outputs.found == 'true'
+  build-apk:
+    name: Build apk ${{ matrix.arch }}
+    if: github.event_name == 'release' || github.event.label.name == 'run-build' || (github.event_name == 'pull_request' && github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-build'))
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: x86/64
+            arch: x86_64
+            sdk_name: openwrt-sdk-25.12.0-x86-64_gcc-14.3.0_musl.Linux-x86_64
+          - target: ramips/mt7621
+            arch: mipsel_24kc
+            sdk_name: openwrt-sdk-25.12.0-ramips-mt7621_gcc-14.3.0_musl.Linux-x86_64
+          - target: ath79/generic
+            arch: mips_24kc
+            sdk_name: openwrt-sdk-25.12.0-ath79-generic_gcc-14.3.0_musl.Linux-x86_64
+          - target: mediatek/filogic
+            arch: aarch64_cortex-a53
+            sdk_name: openwrt-sdk-25.12.0-mediatek-filogic_gcc-14.3.0_musl.Linux-x86_64
+          - target: bcm27xx/bcm2711
+            arch: aarch64_cortex-a72
+            sdk_name: openwrt-sdk-25.12.0-bcm27xx-bcm2711_gcc-14.3.0_musl.Linux-x86_64
+          - target: ipq40xx/generic
+            arch: arm_cortex-a7_neon-vfpv4
+            sdk_name: openwrt-sdk-25.12.0-ipq40xx-generic_gcc-14.3.0_musl_eabi.Linux-x86_64
+          - target: mvebu/cortexa9
+            arch: arm_cortex-a9_vfpv3-d16
+            sdk_name: openwrt-sdk-25.12.0-mvebu-cortexa9_gcc-14.3.0_musl_eabi.Linux-x86_64
+          - target: ipq806x/generic
+            arch: arm_cortex-a15_neon-vfpv4
+            sdk_name: openwrt-sdk-25.12.0-ipq806x-generic_gcc-14.3.0_musl_eabi.Linux-x86_64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build minified assets
+        run: pnpm run build
+
+      - name: Download and extract SDK
+        run: |
+          SDK_URL="https://downloads.openwrt.org/releases/25.12.0/targets/${{ matrix.target }}/${{ matrix.sdk_name }}.tar.zst"
+          curl -L -o sdk.tar.zst "$SDK_URL"
+          tar --use-compress-program=unzstd -xf sdk.tar.zst
+          rm sdk.tar.zst
+
+      - name: Copy package files
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="0.0.0-pr${{ github.event.pull_request.number }}"
+          fi
+          mkdir -p ${{ matrix.sdk_name }}/package/moci
+          sed "s/PKG_VERSION:=.*/PKG_VERSION:=$VERSION/" Makefile > ${{ matrix.sdk_name }}/package/moci/Makefile
+          cp -r dist ${{ matrix.sdk_name }}/package/moci/
+          cp rpcd-acl.json ${{ matrix.sdk_name }}/package/moci/
+          cp -r files ${{ matrix.sdk_name }}/package/moci/
+
+      - name: Update feeds
+        working-directory: ${{ matrix.sdk_name }}
+        run: |
+          ./scripts/feeds update -a
+          ./scripts/feeds install -a
+
+      - name: Build apk package
+        working-directory: ${{ matrix.sdk_name }}
+        run: |
+          make defconfig
+          make package/moci/compile V=s
+
+      - name: Find and rename apk
+        id: find_apk
+        working-directory: ${{ matrix.sdk_name }}
+        run: |
+          APK_FILE=$(find bin/packages -name "moci*.apk" | head -n 1)
+          if [ -z "$APK_FILE" ]; then
+            echo "Error: apk package not found!"
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="0.0.0-pr${{ github.event.pull_request.number }}"
+          fi
+          NEW_NAME="moci_${VERSION}-r1_${{ matrix.arch }}.apk"
+          mv "$APK_FILE" "/tmp/$NEW_NAME"
+          echo "package_name=$NEW_NAME" >> $GITHUB_OUTPUT
+
+      - name: Upload to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: /tmp/${{ steps.find_apk.outputs.package_name }}
+
+      - name: Upload artifact
+        if: github.event_name != 'release'
         uses: actions/upload-artifact@v4
         with:
           name: moci-apk-${{ matrix.arch }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -89,37 +89,63 @@ jobs:
           ./scripts/feeds update -a
           ./scripts/feeds install -a
 
-      - name: Configure SDK
+      - name: Configure SDK (ipk)
         working-directory: ${{ matrix.sdk_name }}
         run: |
           make defconfig
 
-      - name: Build package
+      - name: Build ipk package
         working-directory: ${{ matrix.sdk_name }}
         run: |
           make package/moci/compile V=s
 
-      - name: Find package
-        id: find_package
+      - name: Find ipk package
+        id: find_ipk
         working-directory: ${{ matrix.sdk_name }}
         run: |
           IPK_FILE=$(find bin/packages -name "moci_*.ipk" | head -n 1)
           if [ -z "$IPK_FILE" ]; then
-            echo "Error: Package not found!"
+            echo "Error: ipk package not found!"
             exit 1
           fi
-          echo "package_path=$IPK_FILE" >> $GITHUB_OUTPUT
           VERSION=${GITHUB_REF#refs/tags/}
           ARCH_SUFFIX="${{ matrix.arch }}"
           NEW_NAME="moci_${VERSION}-r1_${ARCH_SUFFIX}.ipk"
+          mv "$IPK_FILE" "/tmp/$NEW_NAME"
           echo "package_name=$NEW_NAME" >> $GITHUB_OUTPUT
 
-      - name: Rename package
+      - name: Configure SDK (apk)
         working-directory: ${{ matrix.sdk_name }}
         run: |
-          mv ${{ steps.find_package.outputs.package_path }} /tmp/${{ steps.find_package.outputs.package_name }}
+          echo "CONFIG_USE_APK=y" >> .config
+          make defconfig
+
+      - name: Build apk package
+        working-directory: ${{ matrix.sdk_name }}
+        run: |
+          make package/moci/clean V=s
+          make package/moci/compile V=s
+
+      - name: Find apk package
+        id: find_apk
+        working-directory: ${{ matrix.sdk_name }}
+        run: |
+          APK_FILE=$(find bin/packages -name "moci*.apk" | head -n 1)
+          if [ -z "$APK_FILE" ]; then
+            echo "Warning: apk package not found, skipping"
+            echo "found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          VERSION=${GITHUB_REF#refs/tags/}
+          ARCH_SUFFIX="${{ matrix.arch }}"
+          NEW_NAME="moci_${VERSION}-r1_${ARCH_SUFFIX}.apk"
+          mv "$APK_FILE" "/tmp/$NEW_NAME"
+          echo "package_name=$NEW_NAME" >> $GITHUB_OUTPUT
+          echo "found=true" >> $GITHUB_OUTPUT
 
       - name: Upload to release
         uses: softprops/action-gh-release@v2
         with:
-          files: /tmp/${{ steps.find_package.outputs.package_name }}
+          files: |
+            /tmp/${{ steps.find_ipk.outputs.package_name }}
+            /tmp/${{ steps.find_apk.outputs.package_name }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,7 +42,7 @@ jobs:
           if [ "${{ github.event_name }}" = "release" ]; then
             echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
-            echo "version=0.0.0-pr${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "version=0.0.0.${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Upload dist

--- a/README.md
+++ b/README.md
@@ -73,14 +73,23 @@ scp -r moci/* root@192.168.1.1:/www/moci/
 
 ### Option 1: Package (Recommended)
 
-Download the ipk for your architecture from [Releases](https://github.com/HudsonGraeme/MoCI/releases/latest):
+Download the package for your architecture from [Releases](https://github.com/HudsonGraeme/MoCI/releases/latest).
+
+**OpenWrt 24.10 and earlier (opkg):**
 
 ```bash
 wget https://github.com/HudsonGraeme/MoCI/releases/latest/download/moci_VERSION_ARCH.ipk
 opkg install moci_VERSION_ARCH.ipk
 ```
 
-Available architectures: x86_64, ramips/mt7621, ath79, mediatek/filogic, bcm27xx, ipq40xx, mvebu, ipq806x
+**OpenWrt 25.12+ (apk):**
+
+```bash
+wget https://github.com/HudsonGraeme/MoCI/releases/latest/download/moci_VERSION_ARCH.apk
+apk add --allow-untrusted moci_VERSION_ARCH.apk
+```
+
+Available architectures: x86_64, mipsel_24kc, mips_24kc, aarch64_cortex-a53, aarch64_cortex-a72, arm_cortex-a7_neon-vfpv4, arm_cortex-a9_vfpv3-d16, arm_cortex-a15_neon-vfpv4
 
 Replace `VERSION_ARCH` with your specific file from the releases page.
 
@@ -123,7 +132,7 @@ git clone https://github.com/HudsonGraeme/MoCI.git package/moci
 make package/moci/compile
 ```
 
-The package will be in `bin/packages/*/base/moci_*.ipk`
+The package will be in `bin/packages/*/base/moci_*.ipk` (24.10) or `bin/packages/*/base/moci-*.apk` (25.12+)
 
 ---
 


### PR DESCRIPTION
## Summary
- OpenWrt 24.10+ defaults to APK as the package manager on many targets
- Users on these builds get `v2 package format error` when installing `.ipk` files with `apk add`
- The release workflow now builds both `.ipk` and `.apk` formats per architecture so both opkg and apk users are supported

## Test plan
- [ ] Trigger a release build and verify both `.ipk` and `.apk` artifacts are uploaded per architecture
- [ ] Install `.apk` on an OpenWrt 24.10+ device using `apk add --allow-untrusted`
- [ ] Verify `.ipk` installs still work on opkg-based devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to support packaging applications in both APK and IPK formats, providing users with multiple installation options in releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->