### PR TITLE
Fix mobile nav not opening

### DIFF
--- a/moci/app.css
+++ b/moci/app.css
@@ -1210,7 +1210,7 @@ select.form-input {
 	}
 
 	.nav {
-		position: absolute;
+		position: fixed;
 		top: 64px;
 		left: 0;
 		right: 0;
@@ -1222,7 +1222,7 @@ select.form-input {
 		border-bottom: 1px solid var(--glass-border);
 		box-shadow: 0 4px 30px rgba(0, 0, 0, 0.5);
 		display: none;
-		z-index: 99;
+		z-index: 200;
 	}
 
 	.nav.open {


### PR DESCRIPTION
## Summary
- Nav drawer used `position: absolute` inside a `position: sticky` header with `backdrop-filter`, which clips overflowing children
- Changed to `position: fixed` so the nav escapes the header's containing block
- Bumped z-index to 200 (above header's 100) to ensure it renders on top

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Improved navigation positioning and layering on mobile and tablet devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->