### PR TITLE
Add lighttpd/TurrisOS support

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -18,15 +18,15 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: 9
 
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Upload dist
-        uses: actions/upload-artifact@53b83947a5a98c8d113130e565377fae1a50d02f # v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: dist
           path: dist/
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -99,7 +99,7 @@ jobs:
 
       - name: Cache SDK
         id: cache-sdk
-        uses: actions/cache@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ matrix.sdk_name }}
           key: sdk-${{ matrix.sdk_name }}
@@ -157,7 +157,7 @@ jobs:
 
       - name: Upload artifact
         if: github.event_name != 'release'
-        uses: actions/upload-artifact@53b83947a5a98c8d113130e565377fae1a50d02f # v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: moci-ipk-${{ matrix.arch }}
           path: /tmp/${{ steps.find_ipk.outputs.package_name }}
@@ -199,7 +199,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -209,7 +209,7 @@ jobs:
 
       - name: Cache SDK
         id: cache-sdk
-        uses: actions/cache@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ matrix.sdk_name }}
           key: sdk-${{ matrix.sdk_name }}
@@ -267,7 +267,7 @@ jobs:
 
       - name: Upload artifact
         if: github.event_name != 'release'
-        uses: actions/upload-artifact@53b83947a5a98c8d113130e565377fae1a50d02f # v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: moci-apk-${{ matrix.arch }}
           path: /tmp/${{ steps.find_apk.outputs.package_name }}

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ define Package/moci/install
 	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d
 	$(INSTALL_DATA) ./rpcd-acl.json $(1)/usr/share/rpcd/acl.d/moci.json
 
+	$(INSTALL_DIR) $(1)/usr/share/acl.d
+	$(INSTALL_DATA) ./files/ubus-acl-moci.json $(1)/usr/share/acl.d/moci.json
+
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/moci.config $(1)/etc/config/moci
 
@@ -60,6 +63,7 @@ endef
 define Package/moci/postinst
 #!/bin/sh
 [ -n "$${IPKG_INSTROOT}" ] || {
+	kill -HUP $$(pidof ubusd) 2>/dev/null
 	/etc/init.d/rpcd restart
 	if [ -f /etc/init.d/lighttpd ]; then
 		/etc/init.d/lighttpd restart

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ define Package/moci/install
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/moci.config $(1)/etc/config/moci
 
-	$(INSTALL_DIR) $(1)/www/moci
 	$(INSTALL_BIN) ./files/ubus.cgi $(1)/www/moci/ubus.cgi
 
 	$(INSTALL_DIR) $(1)/etc/lighttpd/conf.d

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,13 @@ define Package/moci
   CATEGORY:=Administration
   TITLE:=MoCI - Modern Configuration Interface for OpenWrt
   PKGARCH:=all
-  DEPENDS:=+uhttpd +rpcd
+  DEPENDS:=+rpcd +jsonfilter
 endef
 
 define Package/moci/description
   Modern web interface for OpenWrt routers.
   Pure vanilla JavaScript SPA using OpenWrt's native ubus API.
+  Works with uhttpd (standard OpenWrt) or lighttpd (TurrisOS).
 endef
 
 define Build/Compile
@@ -30,6 +31,11 @@ define Package/moci/install
 	$(INSTALL_DIR) $(1)/www/moci
 	$(INSTALL_DATA) ./dist/moci/index.html $(1)/www/moci/
 	$(INSTALL_DATA) ./dist/moci/app.css $(1)/www/moci/
+	$(INSTALL_DATA) ./dist/moci/manifest.json $(1)/www/moci/
+
+	$(INSTALL_DIR) $(1)/www/moci/icons
+	$(INSTALL_DATA) ./dist/moci/icons/icon-192.png $(1)/www/moci/icons/
+	$(INSTALL_DATA) ./dist/moci/icons/icon-512.png $(1)/www/moci/icons/
 
 	$(INSTALL_DIR) $(1)/www/moci/js
 	$(INSTALL_DATA) ./dist/moci/js/core.js $(1)/www/moci/js/
@@ -44,13 +50,24 @@ define Package/moci/install
 
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/moci.config $(1)/etc/config/moci
+
+	$(INSTALL_DIR) $(1)/www/moci
+	$(INSTALL_BIN) ./files/ubus.cgi $(1)/www/moci/ubus.cgi
+
+	$(INSTALL_DIR) $(1)/etc/lighttpd/conf.d
+	$(INSTALL_DATA) ./files/lighttpd-moci.conf $(1)/etc/lighttpd/conf.d/50-moci.conf
 endef
 
 define Package/moci/postinst
 #!/bin/sh
 [ -n "$${IPKG_INSTROOT}" ] || {
 	/etc/init.d/rpcd restart
-	echo "MoCI installed. Access at http://[router-ip]/moci/"
+	if [ -f /etc/init.d/lighttpd ]; then
+		/etc/init.d/lighttpd restart
+		echo "MoCI installed (lighttpd). Access at http://[router-ip]/moci/"
+	else
+		echo "MoCI installed. Access at http://[router-ip]/moci/"
+	fi
 }
 endef
 

--- a/files/lighttpd-moci.conf
+++ b/files/lighttpd-moci.conf
@@ -1,0 +1,12 @@
+server.modules += ( "mod_cgi", "mod_setenv" )
+
+$HTTP["url"] =~ "^/moci/" {
+    alias.url = ( "/moci/" => "/www/moci/" )
+    index-file.names = ( "index.html" )
+}
+
+$HTTP["url"] == "/ubus" {
+    alias.url = ( "/ubus" => "/www/moci/ubus.cgi" )
+    cgi.assign = ( ".cgi" => "" )
+    setenv.add-environment = ( "PATH" => "/usr/bin:/usr/sbin:/bin:/sbin" )
+}

--- a/files/lighttpd-moci.conf
+++ b/files/lighttpd-moci.conf
@@ -1,4 +1,4 @@
-server.modules += ( "mod_cgi", "mod_setenv" )
+server.modules += ( "mod_alias", "mod_cgi", "mod_setenv" )
 
 $HTTP["url"] =~ "^/moci/" {
     alias.url = ( "/moci/" => "/www/moci/" )

--- a/files/ubus-acl-moci.json
+++ b/files/ubus-acl-moci.json
@@ -1,0 +1,14 @@
+{
+	"user": "http",
+	"access": {
+		"session": { "methods": [ "login", "access", "destroy" ] },
+		"system": { "methods": [ "board", "info", "reboot" ] },
+		"network.interface": { "methods": [ "dump" ] },
+		"network.interface.*": { "methods": [ "up", "down", "status" ] },
+		"network.wireless": { "methods": [ "status" ] },
+		"uci": { "methods": [ "get", "set", "add", "delete", "commit" ] },
+		"file": { "methods": [ "read", "write", "exec" ] },
+		"luci-rpc": { "methods": [ "getDHCPLeases" ] },
+		"service": { "methods": [ "list" ] }
+	}
+}

--- a/files/ubus.cgi
+++ b/files/ubus.cgi
@@ -1,0 +1,138 @@
+#!/bin/sh
+[ "$REQUEST_METHOD" != "POST" ] && printf 'Status: 405\r\n\r\n' && exit
+
+access() {
+  local sid=$1
+  local obj=$2
+  local fun=$3
+
+  local req=$(printf '{ "ubus_rpc_session": "%s", "scope": "ubus", "object": "%s", "function": "%s" }' "$sid" "$obj" "$fun")
+  local res=$(ubus call session access "$req" | jsonfilter -e '@.access')
+
+  [ "$res" = "true" ]
+}
+
+error() {
+  local code=$1
+  local mesg=$2
+
+  printf '{ "jsonrpc": "2.0", "id": "%s", "error": { "code": %d, "message": "%s" } }'  \
+    "${RPC_ID:-null}" "$code" "$mesg"
+
+  exit 1
+}
+
+process() {
+  local request=$1
+
+  eval $(jsonfilter -s "$request" \
+    -e 'RPC_ID=@.id' \
+    -e 'RPC_VERSION=@.jsonrpc' \
+    -e 'RPC_METHOD=@.method' \
+    -e 'RPC_SESSION_ARG=@.params[3].ubus_rpc_session' \
+    -e 'UBUS_SID=@.params[0]' \
+    -e 'UBUS_SERVICE=@.params[1]' \
+    -e 'UBUS_CMD=@.params[2]')
+
+  if [ -z "$RPC_ID" ] || [ "$RPC_VERSION" != "2.0" ]; then
+    error -32600 "Invalid request"
+  fi
+
+  case "$RPC_ID$UBUS_SID$UBUS_SERVICE$UBUS_CMD" in
+    *[^a-zA-Z0-9_.-]*) error -32600 "Invalid request" ;;
+  esac
+
+  case "$RPC_METHOD" in
+    call)
+      UBUS_PAYLOAD=$(jsonfilter -s "$request" -e '@.params[3]')
+
+      case "$UBUS_PAYLOAD" in
+        ""|{*}) : ;;
+        *) error -32602 "Invalid parameters" ;;
+      esac
+
+      if [ -z "$UBUS_PAYLOAD" ] || [ "$UBUS_PAYLOAD" = "{ }" ]; then
+        UBUS_PAYLOAD=$(printf '{ "ubus_rpc_session": "%s" }' "$UBUS_SID")
+      else
+        UBUS_PAYLOAD=$(printf '{ "ubus_rpc_session": "%s", %s' "$UBUS_SID" "${UBUS_PAYLOAD#\{ }")
+      fi
+
+      if [ -n "$RPC_SESSION_ARG" ]; then
+        error -32602 "Invalid parameters"
+      fi
+
+      if ! access "$UBUS_SID" "$UBUS_SERVICE" "$UBUS_CMD"; then
+        error -32002 "Access denied"
+      fi
+
+      ubus_reply=$(ubus call "$UBUS_SERVICE" "$UBUS_CMD" "$UBUS_PAYLOAD")
+      ubus_status=$?
+
+      printf '{ "jsonrpc": "2.0", "id": "%s", "result": [ %d, %s ] }' \
+        "$RPC_ID" "$ubus_status" "${ubus_reply:-null}"
+    ;;
+    list)
+      RPC_PARAMS=$(jsonfilter -s "$request" -e '@.params')
+
+      case "${RPC_PARAMS:-[ ]}" in
+        \[*\]) : ;;
+        *) error -32602 "Invalid parameters" ;;
+      esac
+
+      if [ "${RPC_PARAMS:-[ ]}" = "[ ]" ]; then
+        services=''
+
+        for service in $(ubus list); do
+          services="${services:+$services, }\"$service\""
+        done
+
+        printf '{ "jsonrpc": "2.0", "id": "%s", "result": [ %s ] }' \
+          "$RPC_ID" "$services"
+      else
+        signatures=''
+
+        eval $(jsonfilter -s "$RPC_PARAMS" -e 'indexes=@')
+
+        for i in $indexes; do
+          service=$(jsonfilter -s "$RPC_PARAMS" -e "@[$i]")
+          signature=''
+
+          IFS=$'\n\t'
+          for line in $(ubus -v list "$service" | tail -n +2); do
+            signature="${signature:+$signature, }$line"
+          done
+          IFS=$' \n\t'
+
+          signatures="${signatures:+$signatures, }\"$service\": { $signature }"
+        done
+
+        printf '{ "jsonrpc": "2.0", "id": "%s", "result": { %s } }' \
+          "$RPC_ID" "$signatures"
+      fi
+    ;;
+    *)
+      error -32601 "Method not found"
+    ;;
+  esac
+}
+
+body=$(cat)
+type=$(jsonfilter -s "$body" -t '@')
+
+printf 'Content-Type: application/json\r\n\r\n'
+
+if [ "$type" = "array" ]; then
+  first=true
+  printf '['
+  jsonfilter -s "$body" -e '@.*' | while read request ; do
+    if ! $first; then
+      printf ','
+    else
+      first=false
+    fi
+    process "$request"
+  done
+  printf ']'
+else
+  process "$body"
+fi

--- a/files/ubus.cgi
+++ b/files/ubus.cgi
@@ -54,7 +54,8 @@ process() {
       if [ -z "$UBUS_PAYLOAD" ] || [ "$UBUS_PAYLOAD" = "{ }" ]; then
         UBUS_PAYLOAD=$(printf '{ "ubus_rpc_session": "%s" }' "$UBUS_SID")
       else
-        UBUS_PAYLOAD=$(printf '{ "ubus_rpc_session": "%s", %s' "$UBUS_SID" "${UBUS_PAYLOAD#\{ }")
+        payload_inner=$(printf '%s' "$UBUS_PAYLOAD" | sed 's/^{[[:space:]]*//')
+        UBUS_PAYLOAD=$(printf '{ "ubus_rpc_session": "%s", %s' "$UBUS_SID" "$payload_inner")
       fi
 
       if [ -n "$RPC_SESSION_ARG" ]; then
@@ -95,6 +96,11 @@ process() {
 
         for i in $indexes; do
           service=$(jsonfilter -s "$RPC_PARAMS" -e "@[$i]")
+
+          case "$service" in
+            *[^a-zA-Z0-9_.-]*) error -32602 "Invalid parameters" ;;
+          esac
+
           signature=''
 
           IFS=$'\n\t'

--- a/scripts/setup-lighttpd-vm.sh
+++ b/scripts/setup-lighttpd-vm.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -e
+
+SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2223 root@localhost"
+
+echo "Setting up lighttpd on ARM VM..."
+echo "Make sure the ARM VM is running (./scripts/start-vm-arm.sh)"
+echo ""
+
+echo "Installing lighttpd and dependencies..."
+${SSH} "opkg update && opkg install lighttpd lighttpd-mod-cgi lighttpd-mod-setenv lighttpd-mod-alias jsonfilter"
+
+echo "Stopping uhttpd..."
+${SSH} "/etc/init.d/uhttpd stop; /etc/init.d/uhttpd disable" || true
+
+echo "Creating MoCI directories..."
+${SSH} "mkdir -p /www/moci/js/modules /www/moci/icons /etc/lighttpd/conf.d"
+
+echo "Deploying MoCI files..."
+cat moci/index.html | ${SSH} "cat > /www/moci/index.html"
+cat moci/app.css | ${SSH} "cat > /www/moci/app.css"
+cat moci/manifest.json | ${SSH} "cat > /www/moci/manifest.json"
+cat moci/icons/icon-192.png | ${SSH} "cat > /www/moci/icons/icon-192.png"
+cat moci/icons/icon-512.png | ${SSH} "cat > /www/moci/icons/icon-512.png"
+cat moci/js/core.js | ${SSH} "cat > /www/moci/js/core.js"
+cat moci/js/modules/dashboard.js | ${SSH} "cat > /www/moci/js/modules/dashboard.js"
+cat moci/js/modules/network.js | ${SSH} "cat > /www/moci/js/modules/network.js"
+cat moci/js/modules/system.js | ${SSH} "cat > /www/moci/js/modules/system.js"
+
+echo "Deploying CGI ubus bridge..."
+cat files/ubus.cgi | ${SSH} "cat > /www/moci/ubus.cgi && chmod +x /www/moci/ubus.cgi"
+
+echo "Deploying lighttpd config..."
+cat files/lighttpd-moci.conf | ${SSH} "cat > /etc/lighttpd/conf.d/50-moci.conf"
+
+echo "Deploying rpcd ACL..."
+cat rpcd-acl.json | ${SSH} "cat > /usr/share/rpcd/acl.d/moci.json"
+
+echo "Restarting services..."
+${SSH} "/etc/init.d/rpcd restart"
+${SSH} "/etc/init.d/lighttpd enable"
+${SSH} "/etc/init.d/lighttpd restart"
+
+echo ""
+echo "Setup complete!"
+echo "Access MoCI at: http://localhost:8081/moci/"
+echo "Login with: root / (no password)"

--- a/scripts/setup-lighttpd-vm.sh
+++ b/scripts/setup-lighttpd-vm.sh
@@ -36,7 +36,12 @@ cat files/lighttpd-moci.conf | ${SSH} "cat > /etc/lighttpd/conf.d/50-moci.conf"
 echo "Deploying rpcd ACL..."
 cat rpcd-acl.json | ${SSH} "cat > /usr/share/rpcd/acl.d/moci.json"
 
+echo "Deploying ubusd ACL for the http user..."
+${SSH} "mkdir -p /usr/share/acl.d"
+cat files/ubus-acl-moci.json | ${SSH} "cat > /usr/share/acl.d/moci.json"
+
 echo "Restarting services..."
+${SSH} "kill -HUP \$(pidof ubusd)"
 ${SSH} "/etc/init.d/rpcd restart"
 ${SSH} "/etc/init.d/lighttpd enable"
 ${SSH} "/etc/init.d/lighttpd restart"

--- a/scripts/setup-qemu-arm.sh
+++ b/scripts/setup-qemu-arm.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -e
+
+OPENWRT_VERSION="24.10.0"
+BASE_URL="https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/armsr/armv7"
+IMAGE_DIR="./vm/arm"
+KERNEL_FILE="${IMAGE_DIR}/openwrt-kernel.bin"
+ROOTFS_FILE="${IMAGE_DIR}/openwrt-rootfs.img"
+
+echo "Setting up OpenWrt ARM QEMU environment..."
+echo "This will emulate ARM Cortex-A (armv7) for testing lighttpd/TurrisOS compatibility"
+echo ""
+
+if ! command -v qemu-system-arm &> /dev/null; then
+    echo "QEMU ARM not found. Installing via Homebrew..."
+    brew install qemu
+fi
+
+mkdir -p "${IMAGE_DIR}"
+
+if [ ! -f "${KERNEL_FILE}" ]; then
+    echo "Downloading OpenWrt ${OPENWRT_VERSION} ARM kernel..."
+    curl -L "${BASE_URL}/openwrt-${OPENWRT_VERSION}-armsr-armv7-generic-kernel.bin" -o "${KERNEL_FILE}"
+else
+    echo "Kernel already exists at ${KERNEL_FILE}"
+fi
+
+if [ ! -f "${ROOTFS_FILE}" ]; then
+    echo "Downloading OpenWrt ${OPENWRT_VERSION} ARM rootfs..."
+    curl -L "${BASE_URL}/openwrt-${OPENWRT_VERSION}-armsr-armv7-generic-ext4-rootfs.img.gz" -o "${IMAGE_DIR}/rootfs.img.gz"
+
+    echo "Extracting rootfs..."
+    gunzip "${IMAGE_DIR}/rootfs.img.gz"
+    mv "${IMAGE_DIR}/rootfs.img" "${ROOTFS_FILE}"
+
+    echo "Resizing rootfs to 512MB..."
+    qemu-img resize "${ROOTFS_FILE}" 512M
+else
+    echo "Rootfs already exists at ${ROOTFS_FILE}"
+fi
+
+echo ""
+echo "Setup complete!"
+echo ""
+echo "Next steps:"
+echo "1. Run: ./scripts/start-vm-arm.sh"
+echo "2. Wait for boot (may take a while - ARM emulation is slow)"
+echo "3. Install lighttpd: opkg update && opkg install lighttpd lighttpd-mod-cgi"
+echo "4. Deploy MoCI with lighttpd config"

--- a/scripts/setup-qemu-arm.sh
+++ b/scripts/setup-qemu-arm.sh
@@ -4,8 +4,7 @@ set -e
 OPENWRT_VERSION="24.10.0"
 BASE_URL="https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/armsr/armv7"
 IMAGE_DIR="./vm/arm"
-KERNEL_FILE="${IMAGE_DIR}/openwrt-kernel.bin"
-ROOTFS_FILE="${IMAGE_DIR}/openwrt-rootfs.img"
+IMAGE_FILE="${IMAGE_DIR}/openwrt-arm.img"
 
 echo "Setting up OpenWrt ARM QEMU environment..."
 echo "This will emulate ARM Cortex-A (armv7) for testing lighttpd/TurrisOS compatibility"
@@ -18,25 +17,18 @@ fi
 
 mkdir -p "${IMAGE_DIR}"
 
-if [ ! -f "${KERNEL_FILE}" ]; then
-    echo "Downloading OpenWrt ${OPENWRT_VERSION} ARM kernel..."
-    curl -L "${BASE_URL}/openwrt-${OPENWRT_VERSION}-armsr-armv7-generic-kernel.bin" -o "${KERNEL_FILE}"
+if [ ! -f "${IMAGE_FILE}" ]; then
+    echo "Downloading OpenWrt ${OPENWRT_VERSION} ARM combined image..."
+    curl -L "${BASE_URL}/openwrt-${OPENWRT_VERSION}-armsr-armv7-generic-ext4-combined-efi.img.gz" -o "${IMAGE_DIR}/combined.img.gz"
+
+    echo "Extracting image..."
+    gunzip "${IMAGE_DIR}/combined.img.gz"
+    mv "${IMAGE_DIR}/combined.img" "${IMAGE_FILE}"
+
+    echo "Resizing image to 512MB..."
+    qemu-img resize "${IMAGE_FILE}" 512M
 else
-    echo "Kernel already exists at ${KERNEL_FILE}"
-fi
-
-if [ ! -f "${ROOTFS_FILE}" ]; then
-    echo "Downloading OpenWrt ${OPENWRT_VERSION} ARM rootfs..."
-    curl -L "${BASE_URL}/openwrt-${OPENWRT_VERSION}-armsr-armv7-generic-ext4-rootfs.img.gz" -o "${IMAGE_DIR}/rootfs.img.gz"
-
-    echo "Extracting rootfs..."
-    gunzip "${IMAGE_DIR}/rootfs.img.gz"
-    mv "${IMAGE_DIR}/rootfs.img" "${ROOTFS_FILE}"
-
-    echo "Resizing rootfs to 512MB..."
-    qemu-img resize "${ROOTFS_FILE}" 512M
-else
-    echo "Rootfs already exists at ${ROOTFS_FILE}"
+    echo "Image already exists at ${IMAGE_FILE}"
 fi
 
 echo ""
@@ -45,5 +37,4 @@ echo ""
 echo "Next steps:"
 echo "1. Run: ./scripts/start-vm-arm.sh"
 echo "2. Wait for boot (may take a while - ARM emulation is slow)"
-echo "3. Install lighttpd: opkg update && opkg install lighttpd lighttpd-mod-cgi"
-echo "4. Deploy MoCI with lighttpd config"
+echo "3. Run: ./scripts/setup-lighttpd-vm.sh (in another terminal)"

--- a/scripts/setup-qemu-arm.sh
+++ b/scripts/setup-qemu-arm.sh
@@ -19,7 +19,7 @@ mkdir -p "${IMAGE_DIR}"
 
 if [ ! -f "${IMAGE_FILE}" ]; then
     echo "Downloading OpenWrt ${OPENWRT_VERSION} ARM combined image..."
-    curl -L "${BASE_URL}/openwrt-${OPENWRT_VERSION}-armsr-armv7-generic-ext4-combined-efi.img.gz" -o "${IMAGE_DIR}/combined.img.gz"
+    curl -fL "${BASE_URL}/openwrt-${OPENWRT_VERSION}-armsr-armv7-generic-ext4-combined-efi.img.gz" -o "${IMAGE_DIR}/combined.img.gz"
 
     echo "Extracting image..."
     gunzip "${IMAGE_DIR}/combined.img.gz"

--- a/scripts/start-vm-arm.sh
+++ b/scripts/start-vm-arm.sh
@@ -2,16 +2,15 @@
 set -e
 
 IMAGE_DIR="./vm/arm"
-KERNEL_FILE="${IMAGE_DIR}/openwrt-kernel.bin"
-ROOTFS_FILE="${IMAGE_DIR}/openwrt-rootfs.img"
+IMAGE_FILE="${IMAGE_DIR}/openwrt-arm.img"
 
-if [ ! -f "${KERNEL_FILE}" ] || [ ! -f "${ROOTFS_FILE}" ]; then
-    echo "OpenWrt ARM images not found. Run ./scripts/setup-qemu-arm.sh first."
+if [ ! -f "${IMAGE_FILE}" ]; then
+    echo "OpenWrt ARM image not found. Run ./scripts/setup-qemu-arm.sh first."
     exit 1
 fi
 
 echo "Starting OpenWrt ARM QEMU..."
-echo "NOTE: ARM emulation on x86/ARM64 host is slow. Be patient."
+echo "NOTE: ARM emulation is slow. Be patient."
 echo ""
 echo "SSH will be available at: localhost:2223"
 echo "Web UI at: http://localhost:8081"
@@ -23,9 +22,8 @@ qemu-system-arm \
     -M virt \
     -cpu cortex-a15 \
     -m 256M \
-    -kernel "${KERNEL_FILE}" \
-    -drive file="${ROOTFS_FILE}",if=virtio,format=raw \
-    -append "root=/dev/vda console=ttyAMA0" \
+    -bios /opt/homebrew/share/qemu/edk2-arm-code.fd \
+    -drive file="${IMAGE_FILE}",if=virtio,format=raw \
     -netdev user,id=lan,hostfwd=tcp::2223-:22,hostfwd=tcp::8081-:80 \
     -device virtio-net-pci,netdev=lan \
     -netdev user,id=wan \

--- a/scripts/start-vm-arm.sh
+++ b/scripts/start-vm-arm.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+IMAGE_DIR="./vm/arm"
+KERNEL_FILE="${IMAGE_DIR}/openwrt-kernel.bin"
+ROOTFS_FILE="${IMAGE_DIR}/openwrt-rootfs.img"
+
+if [ ! -f "${KERNEL_FILE}" ] || [ ! -f "${ROOTFS_FILE}" ]; then
+    echo "OpenWrt ARM images not found. Run ./scripts/setup-qemu-arm.sh first."
+    exit 1
+fi
+
+echo "Starting OpenWrt ARM QEMU..."
+echo "NOTE: ARM emulation on x86/ARM64 host is slow. Be patient."
+echo ""
+echo "SSH will be available at: localhost:2223"
+echo "Web UI at: http://localhost:8081"
+echo ""
+echo "Press Ctrl+A then X to quit QEMU"
+echo ""
+
+qemu-system-arm \
+    -M virt \
+    -cpu cortex-a15 \
+    -m 256M \
+    -kernel "${KERNEL_FILE}" \
+    -drive file="${ROOTFS_FILE}",if=virtio,format=raw \
+    -append "root=/dev/vda console=ttyAMA0" \
+    -netdev user,id=lan,hostfwd=tcp::2223-:22,hostfwd=tcp::8081-:80 \
+    -device virtio-net-pci,netdev=lan \
+    -netdev user,id=wan \
+    -device virtio-net-pci,netdev=wan \
+    -nographic \
+    -no-reboot


### PR DESCRIPTION
## Summary
- Add CGI-based ubus bridge for lighttpd compatibility (from [yurt-page/cgi-ubus](https://github.com/yurt-page/cgi-ubus))
- Add lighttpd configuration snippet installed to `/etc/lighttpd/conf.d/`
- Remove hard uhttpd dependency, add jsonfilter dependency for CGI script
- Include PWA assets (manifest.json, icons) in package install
- Auto-detect lighttpd on postinst and restart appropriately
- Add ARM QEMU scripts for local testing (`scripts/setup-qemu-arm.sh`, `scripts/start-vm-arm.sh`)

## ARM QEMU Testing

Scripts are provided for ARM emulation testing, but note that ARM emulation on x86/ARM64 hosts is extremely slow (services may take 60+ seconds to respond). For practical testing:

1. Use actual Turris hardware, or
2. Use x86 QEMU with lighttpd installed (tests same code path, much faster)

## Test plan
- [ ] Verify standard OpenWrt (uhttpd) installation still works
- [ ] Test on TurrisOS with lighttpd
- [ ] Confirm /ubus endpoint responds to JSON-RPC via CGI

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lighttpd support added as an alternative web server, including server routing and CGI handling.
  * Progressive web app assets (manifest, 192/512 icons) and site static content installed.
  * New CGI JSON-RPC bridge exposing system RPCs with access control and JSON responses.
  * ACL policy for HTTP access to system RPCs included.

* **Tooling**
  * Added scripts to provision/start an ARM QEMU VM and deploy a Lighttpd test VM.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->