### PR TITLE
Add versioned pre-commit hook scoped to staged files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+staged=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(moci/.*\.(js|css|html)|scripts/.*\.js|index\.html)$')
+[ -z "$staged" ] && exit 0
+
+if ! pnpm exec prettier --version >/dev/null 2>&1; then
+	echo "pre-commit: prettier unavailable, skipping format" >&2
+	exit 0
+fi
+
+printf '%s\n' "$staged" | tr '\n' '\0' | xargs -0 pnpm exec prettier --write
+printf '%s\n' "$staged" | tr '\n' '\0' | xargs -0 git add

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,10 @@ pnpm dev:physical 192.168.1.35
 # Edit files in moci/ - changes auto-deploy to target
 ```
 
+Git hooks live in `.githooks/` and are activated automatically by `pnpm install`
+(via the `prepare` script). The pre-commit hook formats staged JS/CSS/HTML with
+prettier; it skips silently if prettier is not installed.
+
 ---
 
 ## Architecture

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"deploy": "scp -r moci/* root@192.168.1.1:/www/moci/",
 		"build": "node scripts/build.js",
 		"format": "prettier --write \"moci/**/*.{js,css,html}\" \"scripts/**/*.js\" \"index.html\"",
-		"format:check": "prettier --check \"moci/**/*.{js,css,html}\" \"scripts/**/*.js\" \"index.html\""
+		"format:check": "prettier --check \"moci/**/*.{js,css,html}\" \"scripts/**/*.js\" \"index.html\"",
+		"prepare": "git config core.hooksPath .githooks"
 	},
 	"devDependencies": {
 		"chokidar": "^5.0.0",


### PR DESCRIPTION
Replaces the unversioned local pre-commit hook with a versioned one in `.githooks/`, activated automatically by `pnpm install` via the `prepare` script (no husky or new dependencies).

## Problems with the old local hook
- Ran `npm run build` and `git add dist/` on every commit, which is how minified dist artifacts ended up tracked in history (removed in #7)
- Blanket `git add moci/ scripts/ index.html` staged unrelated working-tree changes into commits
- Used npm instead of pnpm
- Lived only in `.git/hooks/`, so it was missing in worktrees and fresh clones, and hard-failed when `node_modules` was absent

## New hook behavior
- Formats only the JS/CSS/HTML files that are already staged, then re-stages exactly those files
- Exits cleanly when nothing relevant is staged
- Warns and skips instead of blocking when prettier is unavailable
- No build or dist staging

Verified: formats and re-stages a deliberately misformatted staged file; leaves unstaged files untouched; passes `sh -n`.