### PR TITLE
Fix insecure password change via own rpcd plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ define Package/moci
   CATEGORY:=Administration
   TITLE:=MoCI - Modern Configuration Interface for OpenWrt
   PKGARCH:=all
-  DEPENDS:=+rpcd +jsonfilter
+  DEPENDS:=+rpcd +rpcd-mod-luci +jsonfilter
 endef
 
 define Package/moci/description

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ define Package/moci
   CATEGORY:=Administration
   TITLE:=MoCI - Modern Configuration Interface for OpenWrt
   PKGARCH:=all
-  DEPENDS:=+rpcd +rpcd-mod-luci +jsonfilter
+  DEPENDS:=+rpcd +jsonfilter
 endef
 
 define Package/moci/description
@@ -50,6 +50,9 @@ define Package/moci/install
 
 	$(INSTALL_DIR) $(1)/usr/libexec
 	$(INSTALL_BIN) ./files/moci-pkg-call $(1)/usr/libexec/moci-pkg-call
+
+	$(INSTALL_DIR) $(1)/usr/libexec/rpcd
+	$(INSTALL_BIN) ./files/rpcd-moci $(1)/usr/libexec/rpcd/moci
 
 	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d
 	$(INSTALL_DATA) ./rpcd-acl.json $(1)/usr/share/rpcd/acl.d/moci.json

--- a/files/rpcd-moci
+++ b/files/rpcd-moci
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+case "$1" in
+	list)
+		printf '{ "setPassword": { "username": "str", "password": "str" } }\n'
+		;;
+	call)
+		case "$2" in
+			setPassword)
+				input=$(cat)
+				username=$(printf '%s' "$input" | jsonfilter -e '@.username')
+				password=$(printf '%s' "$input" | jsonfilter -e '@.password')
+
+				case "$username" in
+					root) : ;;
+					*) printf '{ "result": false }\n'; exit 0 ;;
+				esac
+
+				if [ -z "$password" ]; then
+					printf '{ "result": false }\n'
+					exit 0
+				fi
+
+				if printf '%s\n%s\n' "$password" "$password" | passwd "$username" >/dev/null 2>&1; then
+					printf '{ "result": true }\n'
+				else
+					printf '{ "result": false }\n'
+				fi
+				;;
+		esac
+		;;
+esac

--- a/files/ubus-acl-moci.json
+++ b/files/ubus-acl-moci.json
@@ -9,7 +9,7 @@
 		"uci": { "methods": [ "get", "set", "add", "delete", "commit" ] },
 		"file": { "methods": [ "read", "write", "exec" ] },
 		"luci-rpc": { "methods": [ "getDHCPLeases" ] },
-		"luci": { "methods": [ "setPassword" ] },
+		"moci": { "methods": [ "setPassword" ] },
 		"service": { "methods": [ "list" ] }
 	}
 }

--- a/files/ubus-acl-moci.json
+++ b/files/ubus-acl-moci.json
@@ -9,6 +9,7 @@
 		"uci": { "methods": [ "get", "set", "add", "delete", "commit" ] },
 		"file": { "methods": [ "read", "write", "exec" ] },
 		"luci-rpc": { "methods": [ "getDHCPLeases" ] },
+		"luci": { "methods": [ "setPassword" ] },
 		"service": { "methods": [ "list" ] }
 	}
 }

--- a/moci/js/modules/system.js
+++ b/moci/js/modules/system.js
@@ -143,29 +143,17 @@ export default class SystemModule {
 			this.core.showToast('Passwords do not match', 'error');
 			return;
 		}
-		const forbidden = /[`$"'\\;&|<>(){}[\]\n\r]/;
-		if (forbidden.test(newPw)) {
-			this.core.showToast('Password contains invalid characters', 'error');
-			return;
-		}
 		try {
-			await this.core.ubusCall('file', 'write', {
-				path: '/tmp/.passwd_input',
-				data: `${newPw}\n${newPw}\n`
+			const [status, result] = await this.core.ubusCall('luci', 'setPassword', {
+				username: 'root',
+				password: newPw
 			});
-			await this.core.ubusCall('file', 'exec', {
-				command: '/bin/sh',
-				params: ['-c', 'cat /tmp/.passwd_input | passwd root']
-			});
+			if (status !== 0 || !result?.result) throw new Error('setPassword failed');
 			document.getElementById('new-password').value = '';
 			document.getElementById('confirm-password').value = '';
 			this.core.showToast('Password changed', 'success');
 		} catch {
 			this.core.showToast('Failed to change password', 'error');
-		} finally {
-			try {
-				await this.core.ubusCall('file', 'exec', { command: '/bin/rm', params: ['-f', '/tmp/.passwd_input'] });
-			} catch {}
 		}
 	}
 

--- a/moci/js/modules/system.js
+++ b/moci/js/modules/system.js
@@ -144,7 +144,7 @@ export default class SystemModule {
 			return;
 		}
 		try {
-			const [status, result] = await this.core.ubusCall('luci', 'setPassword', {
+			const [status, result] = await this.core.ubusCall('moci', 'setPassword', {
 				username: 'root',
 				password: newPw
 			});

--- a/rpcd-acl.json
+++ b/rpcd-acl.json
@@ -40,7 +40,8 @@
 				"uci": ["set", "add", "delete", "commit"],
 				"file": ["write", "exec"],
 				"system": ["reboot"],
-				"network.interface": ["up", "down"]
+				"network.interface": ["up", "down"],
+				"luci": ["setPassword"]
 			},
 			"uci": [
 				"network",

--- a/rpcd-acl.json
+++ b/rpcd-acl.json
@@ -41,7 +41,7 @@
 				"file": ["write", "exec"],
 				"system": ["reboot"],
 				"network.interface": ["up", "down"],
-				"luci": ["setPassword"]
+				"moci": ["setPassword"]
 			},
 			"uci": [
 				"network",


### PR DESCRIPTION
Replaces the temp-file password flow, which wrote the new root password to /tmp with default permissions before piping it to passwd, leaving it readable by unprivileged local users (including the `http` user the lighttpd CGI bridge runs as) during the change window.

MoCI now ships its own rpcd executable plugin (`/usr/libexec/rpcd/moci`) exposing `setPassword`. rpcd exec plugins receive the request payload on stdin, so the password never appears in any process argv and never touches disk. The method is restricted to the root user. No new dependencies; MoCI stays fully standalone with `+rpcd +jsonfilter`.

Also removes the artificial password charset restriction, which guarded shell interpolation that no longer exists.

Tested end to end in QEMU (OpenWrt 24.10, lighttpd CGI path): a password containing quotes, dollar signs, semicolons, pipes, and backticks round-trips correctly; the old credential is rejected afterwards; non-root usernames are refused.

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Password change flow now uses the system service backend for more reliable updates and shows clear success/error notifications.

* **New Features**
  * Added a small RPC helper to expose a password-set method to the system service.

* **Chores**
  * Updated installation and ACLs so the new service helper and its permissions are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->