### PR TITLE
Serve DHCP leases from own rpcd plugin

### DIFF
--- a/files/rpcd-moci
+++ b/files/rpcd-moci
@@ -1,11 +1,40 @@
 #!/bin/sh
 
+clean_token() {
+	case "$1" in
+		*[!A-Za-z0-9.:_-]*) printf '' ;;
+		*) printf '%s' "$1" ;;
+	esac
+}
+
 case "$1" in
 	list)
-		printf '{ "setPassword": { "username": "str", "password": "str" } }\n'
+		printf '{ "setPassword": { "username": "str", "password": "str" }, "getDHCPLeases": { } }\n'
 		;;
 	call)
 		case "$2" in
+			getDHCPLeases)
+				now=$(date +%s)
+				leases=''
+				if [ -f /tmp/dhcp.leases ]; then
+					while read -r expiry mac ip host _; do
+						mac=$(clean_token "$mac")
+						ip=$(clean_token "$ip")
+						host=$(clean_token "$host")
+						[ -n "$ip" ] || continue
+						case "$ip" in *:*) continue ;; esac
+						[ "$host" = "*" ] && host=''
+						if [ "$expiry" -gt 0 ] 2>/dev/null; then
+							rem=$((expiry - now))
+							[ "$rem" -lt 0 ] && rem=0
+						else
+							rem=0
+						fi
+						leases="${leases:+$leases, }{ \"expires\": $rem, \"macaddr\": \"$mac\", \"ipaddr\": \"$ip\", \"hostname\": \"$host\" }"
+					done < /tmp/dhcp.leases
+				fi
+				printf '{ "dhcp_leases": [ %s ], "dhcp6_leases": [ ] }\n' "$leases"
+				;;
 			setPassword)
 				input=$(cat)
 				username=$(printf '%s' "$input" | jsonfilter -e '@.username')

--- a/files/ubus-acl-moci.json
+++ b/files/ubus-acl-moci.json
@@ -8,8 +8,7 @@
 		"network.wireless": { "methods": [ "status" ] },
 		"uci": { "methods": [ "get", "set", "add", "delete", "commit" ] },
 		"file": { "methods": [ "read", "write", "exec" ] },
-		"luci-rpc": { "methods": [ "getDHCPLeases" ] },
-		"moci": { "methods": [ "setPassword" ] },
+		"moci": { "methods": [ "setPassword", "getDHCPLeases" ] },
 		"service": { "methods": [ "list" ] }
 	}
 }

--- a/moci/js/modules/dashboard.js
+++ b/moci/js/modules/dashboard.js
@@ -287,7 +287,7 @@ export default class DashboardModule {
 
 			let leases = [];
 			try {
-				const [s, r] = await this.core.ubusCall('luci-rpc', 'getDHCPLeases', {});
+				const [s, r] = await this.core.ubusCall('moci', 'getDHCPLeases', {});
 				if (s === 0 && r?.dhcp_leases) leases = r.dhcp_leases;
 			} catch {}
 

--- a/moci/js/modules/network.js
+++ b/moci/js/modules/network.js
@@ -405,7 +405,7 @@ export default class NetworkModule {
 		await this.core.loadResource('dhcp-leases-table', 4, 'dhcp', async () => {
 			let leases = [];
 			try {
-				const [s, r] = await this.core.ubusCall('luci-rpc', 'getDHCPLeases', {});
+				const [s, r] = await this.core.ubusCall('moci', 'getDHCPLeases', {});
 				if (s === 0 && r?.dhcp_leases) leases = r.dhcp_leases;
 			} catch {}
 
@@ -875,7 +875,7 @@ export default class NetworkModule {
 		await this.core.loadResource('dhcp-clients-table', 4, null, async () => {
 			let leases = [];
 			try {
-				const [s, r] = await this.core.ubusCall('luci-rpc', 'getDHCPLeases', {});
+				const [s, r] = await this.core.ubusCall('moci', 'getDHCPLeases', {});
 				if (s === 0 && r?.dhcp_leases) leases = r.dhcp_leases;
 			} catch {}
 

--- a/rpcd-acl.json
+++ b/rpcd-acl.json
@@ -24,7 +24,7 @@
 				"uci": ["get"],
 				"file": ["read"],
 				"system": ["info", "board"],
-				"luci-rpc": ["getDHCPLeases"],
+				"moci": ["getDHCPLeases"],
 				"service": ["list"]
 			},
 			"uci": ["moci"]


### PR DESCRIPTION
Removes the last LuCI backend dependency: the three leases views called `luci-rpc getDHCPLeases`, provided by `rpcd-mod-luci`, so standalone installs without LuCI silently showed no leases.

`rpcd-moci` gains a `getDHCPLeases` method that parses `/tmp/dhcp.leases` (dnsmasq) and returns the same response shape, so the frontend change is just the object name at the three call sites. Lease fields are charset-validated before being emitted; a client-controlled hostname containing JSON metacharacters is blanked instead of corrupting the response. `dhcp6_leases` returns empty for now; odhcpd IPv6 integration can follow if needed.

Tested in QEMU through the lighttpd CGI path with a fabricated lease file covering a normal lease (correct remaining seconds), an infinite lease (expires 0, hostname `*` normalized), and a hostile hostname (neutralized, JSON stays valid).

Closes #45