### PR TITLE
Add default signed add-on feed and feed management UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,19 @@ define Package/moci/install
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/moci.config $(1)/etc/config/moci
 
+	$(INSTALL_DIR) $(1)/etc/opkg/keys
+	$(INSTALL_DATA) ./files/moci-feed.pub $(1)/etc/opkg/keys/bc0c5f67deb5edb8
+	$(INSTALL_CONF) ./files/moci-addons.conf $(1)/etc/opkg/moci-addons.conf
+
 	$(INSTALL_BIN) ./files/ubus.cgi $(1)/www/moci/ubus.cgi
 
 	$(INSTALL_DIR) $(1)/etc/lighttpd/conf.d
 	$(INSTALL_DATA) ./files/lighttpd-moci.conf $(1)/etc/lighttpd/conf.d/50-moci.conf
+endef
+
+define Package/moci/conffiles
+/etc/config/moci
+/etc/opkg/moci-addons.conf
 endef
 
 define Package/moci/postinst

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -166,17 +166,34 @@ runs `/etc/init.d/rpcd reload` so the new ACL takes effect), see
 `examples/moci-addon-pinglog/`. The package reloads rpcd itself; MoCI core never
 holds that privilege.
 
+## Feeds
+
+The official add-on feed lives at
+`https://hudsongraeme.github.io/moci-feed` (the
+[moci-feed](https://github.com/HudsonGraeme/moci-feed) repository, served by
+GitHub Pages, updated independently of MoCI releases). The `moci` package
+ships its usign public key (`files/moci-feed.pub` →
+`/etc/opkg/keys/bc0c5f67deb5edb8`) and a default `/etc/opkg/moci-addons.conf`
+pointing at it, so Browse works out of the box.
+
+Feeds are managed from Add-ons → Browse → Feeds, or via
+`moci-pkg-call feeds | feed-add <name> <url> | feed-remove <name>`. URLs must
+be HTTPS. A third-party feed's usign public key must be installed as
+`/etc/opkg/keys/<fingerprint>` over SSH before its packages pass signature
+verification — MoCI deliberately has no ACL to write trust roots from the web
+UI.
+
 ## Publishing to a feed
 
-`scripts/build-addon-feed.sh` builds the example packages and an `opkg` index
-into `feed/` without an SDK. For a real feed:
+`scripts/build-addon-feed.sh` builds the example add-on packages and an `opkg`
+index into `feed/` without an SDK, then signs the index with
+`$MOCI_FEED_KEY` (default `~/.usign/moci-feed.sec`). For your own feed:
 
 1. Build the `.ipk`/`.apk` (SDK or the script).
 2. Generate the `Packages` index and **sign it with `usign`**; serve `Packages`,
    `Packages.gz`, `Packages.sig` plus the `.ipk`s over HTTPS.
 3. Install the public key on devices as `/etc/opkg/keys/<fingerprint>`.
-4. MoCI registers the feed by writing `/etc/opkg/moci-addons.conf`:
-   `src/gz moci_addons https://feed.example/<arch>`.
+4. Register the feed in Add-ons → Browse → Feeds.
 
 ## Installing
 

--- a/files/moci-addons.conf
+++ b/files/moci-addons.conf
@@ -1,0 +1,1 @@
+src/gz moci_addons https://hudsongraeme.github.io/moci-feed

--- a/files/moci-feed.pub
+++ b/files/moci-feed.pub
@@ -1,0 +1,2 @@
+untrusted comment: MoCI add-on feed signing key
+RWS8DF9n3rXtuOVVaAg4xS0YvORJQdip+KXFXMF4Xp05zRJVLDkbx3AB

--- a/files/moci-pkg-call
+++ b/files/moci-pkg-call
@@ -13,6 +13,17 @@ valid_name() {
 	echo "$1" | grep -qE '^moci-addon-[a-z0-9][a-z0-9-]*$'
 }
 
+FEED_CONF_OPKG=/etc/opkg/moci-addons.conf
+FEED_CONF_APK=/etc/apk/repositories.d/moci-addons.list
+
+valid_feed_name() {
+	echo "$1" | grep -qE '^[a-z0-9][a-z0-9_-]*$'
+}
+
+valid_feed_url() {
+	echo "$1" | grep -qE '^https://[A-Za-z0-9._~:/?#@!$&()*+,;=%-]+$'
+}
+
 case "$action" in
 	list-present)
 		for d in /www/moci/js/addons/*/; do
@@ -39,6 +50,44 @@ case "$action" in
 			apk update
 		else
 			opkg update
+		fi
+		;;
+	feeds)
+		if [ "$pm" = "apk" ]; then
+			[ -f "$FEED_CONF_APK" ] && cat "$FEED_CONF_APK"
+		else
+			[ -f "$FEED_CONF_OPKG" ] && cat "$FEED_CONF_OPKG"
+		fi
+		:
+		;;
+	feed-add)
+		name=$1
+		url=$2
+		valid_feed_name "$name" || { echo "invalid feed name" >&2; exit 1; }
+		valid_feed_url "$url" || { echo "invalid feed url (https only)" >&2; exit 1; }
+		if [ "$pm" = "apk" ]; then
+			mkdir -p "$(dirname "$FEED_CONF_APK")"
+			grep -qxF "$url" "$FEED_CONF_APK" 2>/dev/null && { echo "feed already configured" >&2; exit 1; }
+			echo "$url" >> "$FEED_CONF_APK"
+		else
+			grep -qE "^src/gz $name " "$FEED_CONF_OPKG" 2>/dev/null && { echo "feed name already in use" >&2; exit 1; }
+			echo "src/gz $name $url" >> "$FEED_CONF_OPKG"
+		fi
+		;;
+	feed-remove)
+		if valid_feed_name "$1"; then
+			[ -f "$FEED_CONF_OPKG" ] || exit 0
+			tmp="$FEED_CONF_OPKG.tmp.$$"
+			grep -vE "^src/gz $1 " "$FEED_CONF_OPKG" > "$tmp"
+			mv "$tmp" "$FEED_CONF_OPKG"
+		elif valid_feed_url "$1"; then
+			[ -f "$FEED_CONF_APK" ] || exit 0
+			tmp="$FEED_CONF_APK.tmp.$$"
+			grep -vxF "$1" "$FEED_CONF_APK" > "$tmp"
+			mv "$tmp" "$FEED_CONF_APK"
+		else
+			echo "invalid feed identifier" >&2
+			exit 1
 		fi
 		;;
 	inspect)

--- a/moci/index.html
+++ b/moci/index.html
@@ -1726,6 +1726,31 @@
 								</div>
 							</div>
 							<div class="stat-card" style="margin-top: 24px">
+								<div class="section-title">FEEDS</div>
+								<div id="addon-feeds-list"></div>
+								<div class="diagnostic-form" style="margin-top: 12px">
+									<input
+										type="text"
+										id="feed-name-input"
+										placeholder="name"
+										class="diag-input"
+										style="max-width: 160px"
+									/>
+									<input
+										type="text"
+										id="feed-url-input"
+										placeholder="https://example.com/feed"
+										class="diag-input"
+									/>
+									<button class="action-btn" id="feed-add-btn">ADD</button>
+								</div>
+								<div class="addon-permission-warning" style="margin-top: 12px">
+									Feeds must be usign-signed. Install the feed's public key as
+									/etc/opkg/keys/&lt;fingerprint&gt; over SSH or its packages will fail signature
+									verification.
+								</div>
+							</div>
+							<div class="stat-card" style="margin-top: 24px">
 								<div class="section-title">REGISTRY</div>
 								<div id="registry-addons-list">
 									<div style="text-align: center; color: var(--steel-muted)">Loading registry...</div>

--- a/moci/js/core.js
+++ b/moci/js/core.js
@@ -641,8 +641,8 @@ export class OpenWrtCore {
 		return this.extensionPoints.get(pointName) || [];
 	}
 
-	async pkgCall(action, arg) {
-		const params = arg !== undefined ? [action, String(arg)] : [action];
+	async pkgCall(action, ...args) {
+		const params = [action, ...args.filter(a => a !== undefined).map(String)];
 		const [status, out] = await this.ubusCall(
 			'file',
 			'exec',

--- a/moci/js/modules/addons.js
+++ b/moci/js/modules/addons.js
@@ -61,6 +61,115 @@ export default class AddonsModule {
 			urlInput.addEventListener('keydown', handler);
 			this.cleanups.push(() => urlInput.removeEventListener('keydown', handler));
 		}
+
+		const feedAddBtn = document.getElementById('feed-add-btn');
+		if (feedAddBtn) {
+			const handler = () => this.addFeed();
+			feedAddBtn.addEventListener('click', handler);
+			this.cleanups.push(() => feedAddBtn.removeEventListener('click', handler));
+		}
+
+		const feedUrlInput = document.getElementById('feed-url-input');
+		if (feedUrlInput) {
+			const handler = e => {
+				if (e.key === 'Enter') this.addFeed();
+			};
+			feedUrlInput.addEventListener('keydown', handler);
+			this.cleanups.push(() => feedUrlInput.removeEventListener('keydown', handler));
+		}
+	}
+
+	async renderFeeds() {
+		const el = document.getElementById('addon-feeds-list');
+		if (!el) return;
+
+		let out;
+		try {
+			out = await this.core.pkgCall('feeds');
+		} catch (err) {
+			el.innerHTML = `<div style="color: var(--steel-muted)">Could not read feeds. ${this.core.escapeHtml(err.message)}</div>`;
+			return;
+		}
+
+		const feeds = out
+			.split('\n')
+			.map(l => l.trim())
+			.filter(Boolean)
+			.map(line => {
+				const m = line.match(/^src\/gz\s+(\S+)\s+(\S+)$/);
+				return m ? { id: m[1], name: m[1], url: m[2] } : { id: line, name: '', url: line };
+			});
+
+		if (feeds.length === 0) {
+			el.innerHTML = '<div style="color: var(--steel-muted)">No feeds configured</div>';
+			return;
+		}
+
+		el.innerHTML = feeds
+			.map(
+				f => `<div class="addon-card">
+				<div class="addon-card-info">
+					${f.name ? `<div class="addon-card-name">${this.core.escapeHtml(f.name)}</div>` : ''}
+					<div class="addon-card-desc">${this.core.escapeHtml(f.url)}</div>
+				</div>
+				<div class="addon-card-actions">
+					<button class="action-btn danger" data-action="remove" data-id="${this.core.escapeHtml(f.id)}">REMOVE</button>
+				</div>
+			</div>`
+			)
+			.join('');
+
+		if (this._feedsCleanup) {
+			this._feedsCleanup();
+			const idx = this.cleanups.indexOf(this._feedsCleanup);
+			if (idx >= 0) this.cleanups.splice(idx, 1);
+		}
+		const cleanup = this.core.delegateActions('addon-feeds-list', {
+			remove: id => this.removeFeed(id)
+		});
+		if (cleanup) {
+			this._feedsCleanup = cleanup;
+			this.cleanups.push(cleanup);
+		}
+	}
+
+	async addFeed() {
+		const nameInput = document.getElementById('feed-name-input');
+		const urlInput = document.getElementById('feed-url-input');
+		const name = nameInput?.value.trim() || '';
+		const url = urlInput?.value.trim() || '';
+
+		if (!/^[a-z0-9][a-z0-9_-]*$/.test(name)) {
+			this.core.showToast('Feed name: lowercase letters, digits, - and _ only', 'error');
+			return;
+		}
+		if (!/^https:\/\/\S+$/.test(url)) {
+			this.core.showToast('Feed URL must be https://', 'error');
+			return;
+		}
+
+		try {
+			await this.core.pkgCall('feed-add', name, url);
+		} catch (err) {
+			this.core.showToast('Could not add feed: ' + err.message, 'error');
+			return;
+		}
+
+		if (nameInput) nameInput.value = '';
+		if (urlInput) urlInput.value = '';
+		this.core.showToast(`Feed ${name} added`, 'success');
+		this.renderBrowse();
+	}
+
+	async removeFeed(id) {
+		try {
+			await this.core.pkgCall('feed-remove', id);
+		} catch (err) {
+			this.core.showToast('Could not remove feed: ' + err.message, 'error');
+			return;
+		}
+		this.core.showToast('Feed removed', 'success');
+		this.renderBrowse();
 	}
 
 	async renderInstalled() {
@@ -116,13 +225,15 @@ export default class AddonsModule {
 	async renderBrowse() {
 		const listEl = document.getElementById('registry-addons-list');
 		if (!listEl) return;
+
+		this.renderFeeds();
 		listEl.innerHTML = '<div style="text-align: center; color: var(--steel-muted)">Refreshing feed…</div>';
 
+		let updateWarning = '';
 		try {
 			await this.core.pkgCall('update');
 		} catch (err) {
-			listEl.innerHTML = `<div style="text-align: center; color: var(--steel-muted)">Feed unavailable. ${this.core.escapeHtml(err.message)}</div>`;
-			return;
+			updateWarning = `Feed update failed: ${err.message}. Showing cached package lists.`;
 		}
 
 		let packages;
@@ -142,22 +253,28 @@ export default class AddonsModule {
 		}
 
 		this.installedPackages = await this.core.listInstalledPackages();
-		this.renderRegistry(packages);
+		this.renderRegistry(packages, updateWarning);
 	}
 
-	renderRegistry(packages) {
+	renderRegistry(packages, warning) {
 		const listEl = document.getElementById('registry-addons-list');
 		if (!listEl) return;
 
+		const warningHtml = warning
+			? `<div class="addon-permission-warning" style="margin-bottom: 12px">${this.core.escapeHtml(warning)}</div>`
+			: '';
+
 		if (packages.length === 0) {
-			listEl.innerHTML = '<div style="text-align: center; color: var(--steel-muted)">No add-ons in feed</div>';
+			listEl.innerHTML = `${warningHtml}<div style="text-align: center; color: var(--steel-muted)">No add-ons in feed</div>`;
 			return;
 		}
 
-		listEl.innerHTML = packages
-			.map(p => {
-				const installed = this.installedPackages.has(p.name);
-				return `<div class="addon-card">
+		listEl.innerHTML =
+			warningHtml +
+			packages
+				.map(p => {
+					const installed = this.installedPackages.has(p.name);
+					return `<div class="addon-card">
 				<div class="addon-card-info">
 					<div class="addon-card-name">${this.core.escapeHtml(this.addonId(p.name))}</div>
 					<div class="addon-card-desc">${this.core.escapeHtml(p.description || '')}</div>
@@ -171,8 +288,8 @@ export default class AddonsModule {
 					}
 				</div>
 			</div>`;
-			})
-			.join('');
+				})
+				.join('');
 
 		if (this._registryCleanup) {
 			this._registryCleanup();

--- a/rpcd-acl.json
+++ b/rpcd-acl.json
@@ -16,7 +16,8 @@
 				"/usr/libexec/moci-pkg-call list-present": ["exec"],
 				"/usr/libexec/moci-pkg-call list-installed": ["exec"],
 				"/usr/libexec/moci-pkg-call list-available": ["exec"],
-				"/usr/libexec/moci-pkg-call inspect *": ["exec"]
+				"/usr/libexec/moci-pkg-call inspect *": ["exec"],
+				"/usr/libexec/moci-pkg-call feeds": ["exec"]
 			},
 			"ubus": {
 				"network.interface": ["dump"],
@@ -34,7 +35,8 @@
 				"/usr/libexec/moci-pkg-call install *": ["exec"],
 				"/usr/libexec/moci-pkg-call remove *": ["exec"],
 				"/usr/libexec/moci-pkg-call update": ["exec"],
-				"/etc/opkg/moci-addons.conf": ["write"]
+				"/usr/libexec/moci-pkg-call feed-add *": ["exec"],
+				"/usr/libexec/moci-pkg-call feed-remove *": ["exec"]
 			},
 			"ubus": {
 				"uci": ["set", "add", "delete", "commit"],

--- a/scripts/build-addon-feed.sh
+++ b/scripts/build-addon-feed.sh
@@ -13,7 +13,7 @@ TARFLAGS="--format gnutar --uid 0 --gid 0 --uname root --gname root --no-mac-met
 rm -rf "$OUT"
 mkdir -p "$OUT"
 
-srcdir() { [ "$1" = "moci" ] && echo "$ROOT" || echo "$EX/$1"; }
+srcdir() { echo "$EX/$1"; }
 
 field() { sed -n "s/^$2:=//p" "$1/Makefile" | head -n1; }
 
@@ -22,17 +22,6 @@ stage_files() {
 	data="$2"
 	files="$EX/$name/files"
 	case "$name" in
-		moci)
-			mkdir -p "$data/www/moci/js/modules" "$data/www/moci/js/addons" "$data/usr/libexec" "$data/usr/share/rpcd/acl.d" "$data/etc/config"
-			cp "$ROOT/dist/moci/index.html" "$ROOT/dist/moci/app.css" "$data/www/moci/"
-			cp "$ROOT/dist/moci/js/core.js" "$data/www/moci/js/"
-			for m in dashboard network system vpn services addons; do
-				cp "$ROOT/dist/moci/js/modules/$m.js" "$data/www/moci/js/modules/"
-			done
-			install -m 0755 "$ROOT/files/moci-pkg-call" "$data/usr/libexec/moci-pkg-call"
-			cp "$ROOT/rpcd-acl.json" "$data/usr/share/rpcd/acl.d/moci.json"
-			cp "$ROOT/files/moci.config" "$data/etc/config/moci"
-			;;
 		moci-addon-speedtest)
 			mkdir -p "$data/www/moci/js/addons/speedtest"
 			cp "$files/manifest.json" "$files/addon.js" "$files/style.css" "$data/www/moci/js/addons/speedtest/"
@@ -50,14 +39,6 @@ stage_files() {
 write_control_scripts() {
 	name=$1
 	ctrl="$2"
-	if [ "$name" = "moci" ]; then
-		cat > "$ctrl/postinst" <<'EOF'
-#!/bin/sh
-[ -n "${IPKG_INSTROOT}" ] || /etc/init.d/rpcd restart
-EOF
-		chmod 0755 "$ctrl/postinst"
-		return 0
-	fi
 	[ "$name" = "moci-addon-pinglog" ] || return 0
 	cat > "$ctrl/postinst" <<'EOF'
 #!/bin/sh
@@ -145,11 +126,28 @@ EOF
 
 PACKAGES="$OUT/Packages"
 : > "$PACKAGES"
-for name in moci moci-addon-speedtest moci-addon-pinglog; do
+for name in moci-addon-speedtest moci-addon-pinglog; do
 	build_ipk "$name"
 	index_entry "$name" >> "$PACKAGES"
 done
 
-gzip -k -f "$PACKAGES"
+gzip -kn -f "$PACKAGES"
+
+KEY="${MOCI_FEED_KEY:-$HOME/.usign/moci-feed.sec}"
+USIGN=$(command -v usign || true)
+[ -n "$USIGN" ] || [ ! -x "$HOME/.local/bin/usign" ] || USIGN="$HOME/.local/bin/usign"
+if [ -n "$USIGN" ] && [ -f "$KEY" ]; then
+	"$USIGN" -S -m "$PACKAGES" -s "$KEY" -x "$PACKAGES.sig"
+	echo "feed signed with $KEY"
+else
+	echo "WARNING: feed NOT signed (usign or $KEY missing)" >&2
+fi
+
 echo "feed index: $PACKAGES(.gz)"
 ls -l "$OUT"
+
+REPO="${MOCI_FEED_REPO:-$ROOT/../moci-feed}"
+if [ -d "$REPO/.git" ]; then
+	cp "$OUT"/*.ipk "$PACKAGES" "$PACKAGES.gz" "$PACKAGES.sig" "$REPO/"
+	echo "copied feed to $REPO -- commit and push there to publish"
+fi


### PR DESCRIPTION
## Summary
- Ship the moci-feed usign public key (`/etc/opkg/keys/bc0c5f67deb5edb8`) and a default `/etc/opkg/moci-addons.conf` pointing at https://hudsongraeme.github.io/moci-feed, so Add-ons → Browse works out of the box
- New `moci-pkg-call` actions `feeds` / `feed-add <name> <url>` / `feed-remove` with strict name and https-only URL validation, exposed through the rpcd ACL; the raw file-write grant on moci-addons.conf is removed in favor of these validated paths
- Feed management UI in the Browse tab (list, add, remove); Browse now degrades to cached package lists with a warning when a feed update fails instead of bailing
- `build-addon-feed.sh`: drop the stale core-moci packaging (referenced modules that no longer exist), build add-ons only, sign the index with usign (`~/.usign/moci-feed.sec` or $MOCI_FEED_KEY), and copy artifacts to a moci-feed checkout for publishing
- Feed artifacts live in the new [moci-feed](https://github.com/HudsonGraeme/moci-feed) repo served by GitHub Pages, so feed updates are independent of MoCI releases and dev-branch state

## Security
- Index signing key generated fresh (the previous feed signature's key was unrecoverable); private key stays offline in `~/.usign`, only the public key ships
- Trust roots cannot be written from the web UI; third-party feed keys must be installed over SSH
- `/etc/opkg/moci-addons.conf` is a conffile, so user feed edits survive upgrades