### PR TITLE
Add system and kernel log viewers to System page

### DIFF
--- a/moci/index.html
+++ b/moci/index.html
@@ -1349,6 +1349,7 @@
 						<div class="tabs">
 							<button class="tab-btn active" data-tab="general">GENERAL</button>
 							<button class="tab-btn" data-tab="admin">ADMINISTRATION</button>
+							<button class="tab-btn" data-tab="logs">LOGS</button>
 							<button class="tab-btn" data-tab="backup">BACKUP/RESTORE</button>
 							<button class="tab-btn" data-tab="software">SOFTWARE</button>
 							<button class="tab-btn" data-tab="startup">STARTUP</button>
@@ -1372,6 +1373,29 @@
 								</div>
 								<div class="quick-actions">
 									<button class="action-btn" id="save-general-btn">SAVE CHANGES</button>
+								</div>
+							</div>
+						</div>
+
+						<div class="tab-content hidden" id="tab-logs">
+							<div class="stat-card">
+								<div class="section-title">SYSTEM LOG</div>
+								<div class="diagnostic-form" style="margin-bottom: 12px">
+									<input type="text" id="syslog-filter" placeholder="Filter..." class="diag-input" />
+									<button class="action-btn" id="refresh-syslog-btn">REFRESH</button>
+								</div>
+								<div class="log-viewer" id="syslog-output" style="max-height: 600px">
+									<div class="log-line">Loading...</div>
+								</div>
+							</div>
+							<div class="stat-card" style="margin-top: 24px">
+								<div class="section-title">KERNEL LOG</div>
+								<div class="diagnostic-form" style="margin-bottom: 12px">
+									<input type="text" id="klog-filter" placeholder="Filter..." class="diag-input" />
+									<button class="action-btn" id="refresh-klog-btn">REFRESH</button>
+								</div>
+								<div class="log-viewer" id="klog-output" style="max-height: 600px">
+									<div class="log-line">Loading...</div>
 								</div>
 							</div>
 						</div>

--- a/moci/js/core.js
+++ b/moci/js/core.js
@@ -825,6 +825,23 @@ export class OpenWrtCore {
 		tbody.innerHTML = items.map(rowFn).join('');
 	}
 
+	renderLogLines(element, lines, emptyMsg = 'No logs available') {
+		if (!element) return;
+		if (!lines.length) {
+			element.innerHTML = `<div class="log-line">${this.escapeHtml(emptyMsg)}</div>`;
+			return;
+		}
+		element.innerHTML = lines
+			.map(line => {
+				let className = 'log-line';
+				const lower = line.toLowerCase();
+				if (lower.includes('error') || lower.includes('fail')) className += ' error';
+				else if (lower.includes('warn')) className += ' warn';
+				return `<div class="${className}">${this.escapeHtml(line)}</div>`;
+			})
+			.join('');
+	}
+
 	filterUciSections(config, type) {
 		return Object.entries(config)
 			.filter(([, v]) => v['.type'] === type)

--- a/moci/js/modules/dashboard.js
+++ b/moci/js/modules/dashboard.js
@@ -230,9 +230,11 @@ export default class DashboardModule {
 	}
 
 	async updateSystemLog() {
+		const logEl = document.getElementById('system-log');
+		if (!logEl) return;
 		try {
 			const [status, result] = await this.core.ubusCall('file', 'exec', {
-				command: '/usr/libexec/syslog-wrapper',
+				command: '/sbin/logread',
 				params: []
 			});
 			if (status !== 0 || !result?.stdout) throw new Error('Failed');
@@ -241,27 +243,10 @@ export default class DashboardModule {
 				.split('\n')
 				.filter(l => l.trim())
 				.slice(-20);
-			const logEl = document.getElementById('system-log');
-			if (!logEl) return;
-
-			if (lines.length === 0) {
-				logEl.innerHTML = '<div class="log-line">No logs available</div>';
-				return;
-			}
-
-			logEl.innerHTML = lines
-				.map(line => {
-					let className = 'log-line';
-					const lower = line.toLowerCase();
-					if (lower.includes('error') || lower.includes('fail')) className += ' error';
-					else if (lower.includes('warn')) className += ' warn';
-					return `<div class="${className}">${this.core.escapeHtml(line)}</div>`;
-				})
-				.join('');
+			this.core.renderLogLines(logEl, lines);
 		} catch (err) {
 			console.error('Failed to load system log:', err);
-			const logEl = document.getElementById('system-log');
-			if (logEl) logEl.innerHTML = '<div class="log-line">No logs available</div>';
+			this.core.renderLogLines(logEl, []);
 		}
 	}
 

--- a/moci/js/modules/system.js
+++ b/moci/js/modules/system.js
@@ -153,7 +153,7 @@ export default class SystemModule {
 		output.innerHTML = '<div class="log-line">Loading...</div>';
 		try {
 			const [s, r] = await this.core.ubusCall('file', 'exec', commands[kind], { timeout: 15000 });
-			if (s !== 0) throw new Error('Command failed');
+			if (s !== 0 || !r || (r.code && r.code !== 0)) throw new Error('Command failed');
 			if (!this._logLines) this._logLines = {};
 			this._logLines[kind] = (r.stdout || '').split('\n').filter(l => l.trim());
 			this.renderLog(kind);

--- a/moci/js/modules/system.js
+++ b/moci/js/modules/system.js
@@ -15,6 +15,7 @@ export default class SystemModule {
 				this.subTabs = this.core.setupSubTabs('system-page', {
 					general: () => this.loadGeneral(),
 					admin: () => this.loadAdmin(),
+					logs: () => this.loadLogs(),
 					backup: () => this.loadBackup(),
 					software: () => this.loadPackages(),
 					startup: () => this.loadStartup(),
@@ -52,11 +53,17 @@ export default class SystemModule {
 				document.getElementById('save-ssh-keys-btn').style.display = 'none';
 				this.core.openModal('ssh-key-modal');
 			},
-			'parse-keys-btn': () => this.parseSSHKeyInput()
+			'parse-keys-btn': () => this.parseSSHKeyInput(),
+			'refresh-syslog-btn': () => this.loadLog('syslog'),
+			'refresh-klog-btn': () => this.loadLog('klog')
 		};
 
 		for (const [id, handler] of Object.entries(buttons)) {
 			document.getElementById(id)?.addEventListener('click', handler);
+		}
+
+		for (const kind of ['syslog', 'klog']) {
+			document.getElementById(`${kind}-filter`)?.addEventListener('input', () => this.renderLog(kind));
 		}
 
 		this.core.setupModal({
@@ -131,6 +138,38 @@ export default class SystemModule {
 	}
 
 	async loadAdmin() {}
+
+	async loadLogs() {
+		await Promise.all([this.loadLog('syslog'), this.loadLog('klog')]);
+	}
+
+	async loadLog(kind) {
+		const commands = {
+			syslog: { command: '/sbin/logread', params: [] },
+			klog: { command: '/bin/dmesg', params: [] }
+		};
+		const output = document.getElementById(`${kind}-output`);
+		if (!output) return;
+		output.innerHTML = '<div class="log-line">Loading...</div>';
+		try {
+			const [s, r] = await this.core.ubusCall('file', 'exec', commands[kind], { timeout: 15000 });
+			if (s !== 0) throw new Error('Command failed');
+			if (!this._logLines) this._logLines = {};
+			this._logLines[kind] = (r.stdout || '').split('\n').filter(l => l.trim());
+			this.renderLog(kind);
+			output.scrollTop = output.scrollHeight;
+		} catch {
+			output.innerHTML = '<div class="log-line error">Failed to load log</div>';
+		}
+	}
+
+	renderLog(kind) {
+		const output = document.getElementById(`${kind}-output`);
+		if (!output || !this._logLines?.[kind]) return;
+		const query = (document.getElementById(`${kind}-filter`)?.value || '').toLowerCase();
+		const lines = this._logLines[kind].filter(l => !query || l.toLowerCase().includes(query));
+		this.core.renderLogLines(output, lines, query ? 'No matching log entries' : 'No logs available');
+	}
 
 	async changePassword() {
 		const newPw = document.getElementById('new-password').value;

--- a/rpcd-acl.json
+++ b/rpcd-acl.json
@@ -17,7 +17,9 @@
 				"/usr/libexec/moci-pkg-call list-installed": ["exec"],
 				"/usr/libexec/moci-pkg-call list-available": ["exec"],
 				"/usr/libexec/moci-pkg-call inspect *": ["exec"],
-				"/usr/libexec/moci-pkg-call feeds": ["exec"]
+				"/usr/libexec/moci-pkg-call feeds": ["exec"],
+				"/sbin/logread": ["exec"],
+				"/bin/dmesg": ["exec"]
 			},
 			"ubus": {
 				"network.interface": ["dump"],


### PR DESCRIPTION
Closes #32.

Adds a LOGS tab to the System page with two viewers, matching luci-mod-status syslog/dmesg:

- **System log** via `/sbin/logread` and **kernel log** via `/bin/dmesg`, each with a live substring filter box, a refresh button, and error/warn line highlighting. Viewers auto-scroll to the newest entries on load.
- **rpcd ACL**: grants `file` exec for `/sbin/logread` and `/bin/dmesg` in the `moci` ACL group, as the issue calls for. Verified on the QEMU VM that without these grants a session whose file-scope permissions come only from the `moci` group gets permission denied from rpcd's per-path exec check.
- **Dashboard fix**: the dashboard's SYSTEM LOG panel called `/usr/libexec/syslog-wrapper`, a binary shipped by LuCI that MoCI does not install, so it showed "No logs available" on any LuCI-less system. It now uses `/sbin/logread` directly, and the log-line rendering (error/warn classification) is shared via a new `core.renderLogLines` used by both the dashboard and the new viewers.

Verified on an OpenWrt 24.10 armsr/armv8 QEMU VM through the lighttpd `/ubus` CGI bridge and in the rendered UI: both viewers populate, the filter narrows live with warn highlighting, refresh reloads, and the dashboard panel renders the tail of logread output.

Testing surfaced a broader standalone-rule gap, filed separately: several existing features (diagnostics ping/traceroute/WoL, WireGuard key generation, some file writes) only pass rpcd's per-path ACL checks when LuCI's ACL groups happen to be installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Logs** tab to the System page with separate views for system and kernel logs.
  * Each log view now includes filtering, refresh controls, and a scrollable output area.

* **Bug Fixes**
  * Log output is now handled more safely and consistently, including clearer empty and error states.
  * Log rendering now supports highlighting warning and error entries for easier scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->