### PR TITLE
Add firewall zones, general settings, and NAT rules

### DIFF
--- a/moci/index.html
+++ b/moci/index.html
@@ -524,6 +524,76 @@
 
 						<div class="tab-content hidden" id="tab-firewall">
 							<div class="stat-card">
+								<div class="section-title">GENERAL SETTINGS</div>
+								<div class="form-group">
+									<label class="form-label">SYN FLOOD PROTECTION</label>
+									<select id="fw-synflood" class="form-input">
+										<option value="1">Enabled</option>
+										<option value="0">Disabled</option>
+									</select>
+								</div>
+								<div class="form-group">
+									<label class="form-label">DROP INVALID PACKETS</label>
+									<select id="fw-drop-invalid" class="form-input">
+										<option value="1">Enabled</option>
+										<option value="0">Disabled</option>
+									</select>
+								</div>
+								<div class="form-group">
+									<label class="form-label">INPUT POLICY</label>
+									<select id="fw-default-input" class="form-input">
+										<option value="ACCEPT">ACCEPT</option>
+										<option value="REJECT">REJECT</option>
+										<option value="DROP">DROP</option>
+									</select>
+								</div>
+								<div class="form-group">
+									<label class="form-label">OUTPUT POLICY</label>
+									<select id="fw-default-output" class="form-input">
+										<option value="ACCEPT">ACCEPT</option>
+										<option value="REJECT">REJECT</option>
+										<option value="DROP">DROP</option>
+									</select>
+								</div>
+								<div class="form-group">
+									<label class="form-label">FORWARD POLICY</label>
+									<select id="fw-default-forward" class="form-input">
+										<option value="ACCEPT">ACCEPT</option>
+										<option value="REJECT">REJECT</option>
+										<option value="DROP">DROP</option>
+									</select>
+								</div>
+								<button class="action-btn" id="save-fw-defaults-btn">SAVE SETTINGS</button>
+							</div>
+
+							<div class="stat-card" style="margin-top: 24px">
+								<div class="section-title">ZONES</div>
+								<button class="action-btn" id="add-zone-btn" style="margin-bottom: 16px">
+									ADD ZONE
+								</button>
+								<table class="data-table" id="zones-table">
+									<thead>
+										<tr>
+											<th>ZONE</th>
+											<th>INPUT</th>
+											<th>OUTPUT</th>
+											<th>FORWARD</th>
+											<th>MASQUERADE</th>
+											<th>NETWORKS</th>
+											<th>ACTIONS</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td colspan="7" style="text-align: center; color: var(--steel-muted)">
+												Loading...
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+
+							<div class="stat-card" style="margin-top: 24px">
 								<div class="section-title">PORT FORWARDING RULES</div>
 								<button class="action-btn" id="add-forward-btn" style="margin-bottom: 16px">
 									ADD RULE
@@ -564,6 +634,33 @@
 											<th>PROTOCOL</th>
 											<th>PORT</th>
 											<th>ACTION</th>
+											<th>ACTIONS</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td colspan="7" style="text-align: center; color: var(--steel-muted)">
+												Loading...
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+
+							<div class="stat-card" style="margin-top: 24px">
+								<div class="section-title">NAT RULES</div>
+								<button class="action-btn" id="add-nat-btn" style="margin-bottom: 16px">
+									ADD RULE
+								</button>
+								<table class="data-table" id="nat-table">
+									<thead>
+										<tr>
+											<th>NAME</th>
+											<th>SOURCE ZONE</th>
+											<th>PROTOCOL</th>
+											<th>ACTION</th>
+											<th>REWRITE IP</th>
+											<th>ENABLED</th>
 											<th>ACTIONS</th>
 										</tr>
 									</thead>
@@ -732,6 +829,164 @@
 								<div class="modal-footer">
 									<button class="action-btn" id="cancel-fw-rule-btn">CANCEL</button>
 									<button class="action-btn" id="save-fw-rule-btn">SAVE RULE</button>
+								</div>
+							</div>
+						</div>
+
+						<div class="modal hidden" id="zone-modal">
+							<div class="modal-backdrop"></div>
+							<div class="modal-content">
+								<div class="modal-header">
+									<h3 class="modal-title">FIREWALL ZONE</h3>
+									<button class="modal-close" id="close-zone-modal">&times;</button>
+								</div>
+								<div class="modal-body">
+									<input type="hidden" id="edit-zone-section" />
+									<div class="form-group">
+										<label class="form-label">ZONE NAME</label>
+										<input type="text" id="edit-zone-name" class="form-input" placeholder="lan" />
+									</div>
+									<div class="form-group">
+										<label class="form-label">INPUT POLICY</label>
+										<select id="edit-zone-input" class="form-input">
+											<option value="ACCEPT">ACCEPT</option>
+											<option value="REJECT">REJECT</option>
+											<option value="DROP">DROP</option>
+										</select>
+									</div>
+									<div class="form-group">
+										<label class="form-label">OUTPUT POLICY</label>
+										<select id="edit-zone-output" class="form-input">
+											<option value="ACCEPT">ACCEPT</option>
+											<option value="REJECT">REJECT</option>
+											<option value="DROP">DROP</option>
+										</select>
+									</div>
+									<div class="form-group">
+										<label class="form-label">FORWARD POLICY</label>
+										<select id="edit-zone-forward" class="form-input">
+											<option value="REJECT">REJECT</option>
+											<option value="ACCEPT">ACCEPT</option>
+											<option value="DROP">DROP</option>
+										</select>
+									</div>
+									<div class="form-group">
+										<label class="form-label">MASQUERADE</label>
+										<select id="edit-zone-masq" class="form-input">
+											<option value="0">No</option>
+											<option value="1">Yes</option>
+										</select>
+									</div>
+									<div class="form-group">
+										<label class="form-label">MSS CLAMPING</label>
+										<select id="edit-zone-mtu-fix" class="form-input">
+											<option value="0">No</option>
+											<option value="1">Yes</option>
+										</select>
+									</div>
+									<div class="form-group">
+										<label class="form-label">COVERED NETWORKS</label>
+										<div id="zone-networks-combo"></div>
+									</div>
+									<div class="form-group">
+										<label class="form-label">ALLOW FORWARD TO ZONES</label>
+										<div id="zone-forward-combo"></div>
+									</div>
+								</div>
+								<div class="modal-footer">
+									<button class="action-btn" id="cancel-zone-btn">CANCEL</button>
+									<button class="action-btn" id="save-zone-btn">SAVE ZONE</button>
+								</div>
+							</div>
+						</div>
+
+						<div class="modal hidden" id="nat-modal">
+							<div class="modal-backdrop"></div>
+							<div class="modal-content">
+								<div class="modal-header">
+									<h3 class="modal-title">NAT RULE</h3>
+									<button class="modal-close" id="close-nat-modal">&times;</button>
+								</div>
+								<div class="modal-body">
+									<input type="hidden" id="edit-nat-section" />
+									<div class="form-group">
+										<label class="form-label">RULE NAME</label>
+										<input
+											type="text"
+											id="edit-nat-name"
+											class="form-input"
+											placeholder="Masquerade guest traffic"
+										/>
+									</div>
+									<div class="form-group">
+										<label class="form-label">SOURCE ZONE</label>
+										<select id="edit-nat-src" class="form-input"></select>
+									</div>
+									<div class="form-group">
+										<label class="form-label">PROTOCOL</label>
+										<select id="edit-nat-proto" class="form-input">
+											<option value="all">Any</option>
+											<option value="tcp">TCP</option>
+											<option value="udp">UDP</option>
+											<option value="tcpudp">TCP+UDP</option>
+											<option value="icmp">ICMP</option>
+										</select>
+									</div>
+									<div class="form-group">
+										<label class="form-label">ACTION</label>
+										<select id="edit-nat-target" class="form-input">
+											<option value="MASQUERADE">MASQUERADE</option>
+											<option value="SNAT">SNAT</option>
+											<option value="ACCEPT">ACCEPT (no rewrite)</option>
+										</select>
+									</div>
+									<div class="form-group">
+										<label class="form-label">SOURCE IP (CIDR)</label>
+										<input
+											type="text"
+											id="edit-nat-src-ip"
+											class="form-input"
+											placeholder="192.168.2.0/24 (leave empty for any)"
+										/>
+									</div>
+									<div class="form-group">
+										<label class="form-label">DESTINATION IP (CIDR)</label>
+										<input
+											type="text"
+											id="edit-nat-dest-ip"
+											class="form-input"
+											placeholder="leave empty for any"
+										/>
+									</div>
+									<div class="form-group">
+										<label class="form-label">REWRITE TO IP (SNAT)</label>
+										<input
+											type="text"
+											id="edit-nat-snat-ip"
+											class="form-input"
+											placeholder="required for SNAT"
+										/>
+									</div>
+									<div class="form-group">
+										<label class="form-label">REWRITE TO PORT (SNAT)</label>
+										<input
+											type="text"
+											id="edit-nat-snat-port"
+											class="form-input"
+											placeholder="leave empty to keep port"
+										/>
+									</div>
+									<div class="form-group">
+										<label class="form-label">ENABLED</label>
+										<select id="edit-nat-enabled" class="form-input">
+											<option value="1">Yes</option>
+											<option value="0">No (Disabled)</option>
+										</select>
+									</div>
+								</div>
+								<div class="modal-footer">
+									<button class="action-btn" id="cancel-nat-btn">CANCEL</button>
+									<button class="action-btn" id="save-nat-btn">SAVE RULE</button>
 								</div>
 							</div>
 						</div>

--- a/moci/js/modules/network.js
+++ b/moci/js/modules/network.js
@@ -17,6 +17,20 @@ const FW_RULE_FIELDS = {
 	'edit-fw-rule-src-ip': 'src_ip'
 };
 
+const NAT_FIELDS = {
+	'edit-nat-name': 'name',
+	'edit-nat-src': 'src',
+	'edit-nat-proto': 'proto',
+	'edit-nat-target': 'target',
+	'edit-nat-src-ip': 'src_ip',
+	'edit-nat-dest-ip': 'dest_ip',
+	'edit-nat-snat-ip': 'snat_ip',
+	'edit-nat-snat-port': 'snat_port',
+	'edit-nat-enabled': 'enabled'
+};
+
+const ZONE_POLICY_BADGES = { ACCEPT: 'success', REJECT: 'warning', DROP: 'error' };
+
 const STATIC_LEASE_FIELDS = {
 	'edit-static-lease-name': 'name',
 	'edit-static-lease-mac': 'mac',
@@ -88,6 +102,8 @@ export default class NetworkModule {
 			{ prefix: 'wireless', save: () => this.saveWireless() },
 			{ prefix: 'forward', save: () => this.saveForward() },
 			{ prefix: 'fw-rule', save: () => this.saveFirewallRule() },
+			{ prefix: 'zone', save: () => this.saveZone() },
+			{ prefix: 'nat', save: () => this.saveNat() },
 			{ prefix: 'static-lease', save: () => this.saveStaticLease() },
 			{ prefix: 'dns-entry', save: () => this.saveDnsEntry() },
 			{ prefix: 'host-entry', save: () => this.saveHostEntry() },
@@ -124,6 +140,22 @@ export default class NetworkModule {
 			});
 		});
 
+		document.getElementById('add-zone-btn')?.addEventListener('click', async () => {
+			this.core.resetModal('zone-modal');
+			await this.loadNetworkNames();
+			this.zoneNetworksCombo().setOptions(this._networkNames);
+			this.zoneNetworksCombo().setSelected([]);
+			this.zoneForwardCombo().setOptions(this.zoneNames());
+			this.zoneForwardCombo().setSelected([]);
+			this.core.openModal('zone-modal');
+		});
+
+		document.getElementById('add-nat-btn')?.addEventListener('click', () => {
+			this.core.resetModal('nat-modal');
+			this.populateNatZoneSelect('');
+			this.core.openModal('nat-modal');
+		});
+
 		document.getElementById('add-bridge-vlan-btn')?.addEventListener('click', () => {
 			this.core.resetModal('bridge-vlan-modal');
 			document.getElementById('edit-bridge-vlan-section').value = '';
@@ -152,6 +184,8 @@ export default class NetworkModule {
 			'wireless-table': { edit: id => this.editWireless(id), delete: id => this.deleteWireless(id) },
 			'firewall-table': { edit: id => this.editForward(id), delete: id => this.deleteForward(id) },
 			'fw-rules-table': { edit: id => this.editFirewallRule(id), delete: id => this.deleteFirewallRule(id) },
+			'zones-table': { edit: id => this.editZone(id), delete: id => this.deleteZone(id) },
+			'nat-table': { edit: id => this.editNat(id), delete: id => this.deleteNat(id) },
 			'dhcp-static-table': { edit: id => this.editStaticLease(id), delete: id => this.deleteStaticLease(id) },
 			'dns-entries-table': { edit: id => this.editDnsEntry(id), delete: id => this.deleteDnsEntry(id) },
 			'hosts-table': { edit: id => this.editHostEntry(id), delete: id => this.deleteHostEntry(id) },
@@ -165,6 +199,7 @@ export default class NetworkModule {
 			if (cleanup) this.cleanups.push(cleanup);
 		}
 
+		document.getElementById('save-fw-defaults-btn')?.addEventListener('click', () => this.saveFwDefaults());
 		document.getElementById('save-qos-config-btn')?.addEventListener('click', () => this.saveQoSConfig());
 		document.getElementById('save-wg-config-btn')?.addEventListener('click', () => this.saveWgConfig());
 		document.getElementById('generate-wg-keys-btn')?.addEventListener('click', () => this.generateWgKeys());
@@ -601,6 +636,11 @@ export default class NetworkModule {
 		await this.core.loadResource('firewall-table', 7, 'firewall', async () => {
 			const [status, result] = await this.core.uciGet('firewall');
 			if (status !== 0 || !result?.values) throw new Error('No data');
+			this._fwCfg = result.values;
+
+			this.renderFwDefaults();
+			this.renderZones();
+			this.renderNatRules();
 
 			const forwards = this.core.filterUciSections(result.values, 'redirect');
 			const rules = this.core.filterUciSections(result.values, 'rule');
@@ -678,6 +718,275 @@ export default class NetworkModule {
 
 	deleteFirewallRule(id) {
 		this.core.uciDeleteEntry('firewall', id, 'Delete this firewall rule?', () => this.loadFirewall());
+	}
+
+	toList(value) {
+		return Array.isArray(value) ? value : value ? [value] : [];
+	}
+
+	zoneNames(exclude) {
+		return this.core
+			.filterUciSections(this._fwCfg || {}, 'zone')
+			.map(z => z.name)
+			.filter(n => n && n !== exclude);
+	}
+
+	zoneForwardings(zoneName) {
+		return this.core.filterUciSections(this._fwCfg || {}, 'forwarding').filter(f => f.src === zoneName);
+	}
+
+	renderPolicyBadge(policy) {
+		const p = (policy || 'REJECT').toUpperCase();
+		return this.core.renderBadge(ZONE_POLICY_BADGES[p] || 'info', p);
+	}
+
+	renderFwDefaults() {
+		const defaults = this.core.filterUciSections(this._fwCfg, 'defaults')[0];
+		this._fwDefaultsSection = defaults?.section || null;
+		const el = id => document.getElementById(id);
+		el('fw-synflood').value = (defaults?.synflood_protect ?? defaults?.syn_flood) === '0' ? '0' : '1';
+		el('fw-drop-invalid').value = defaults?.drop_invalid === '1' ? '1' : '0';
+		el('fw-default-input').value = defaults?.input || 'ACCEPT';
+		el('fw-default-output').value = defaults?.output || 'ACCEPT';
+		el('fw-default-forward').value = defaults?.forward || 'REJECT';
+	}
+
+	async saveFwDefaults() {
+		try {
+			let target = this._fwDefaultsSection;
+			if (!target) {
+				const [, res] = await this.core.uciAdd('firewall', 'defaults');
+				target = res.section;
+			}
+			await this.core.uciSet('firewall', target, {
+				synflood_protect: document.getElementById('fw-synflood').value,
+				drop_invalid: document.getElementById('fw-drop-invalid').value,
+				input: document.getElementById('fw-default-input').value,
+				output: document.getElementById('fw-default-output').value,
+				forward: document.getElementById('fw-default-forward').value
+			});
+			await this.core.uciCommit('firewall');
+			this.core.showToast('Firewall settings saved', 'success');
+			this.loadFirewall();
+		} catch {
+			this.core.showToast('Failed to save firewall settings', 'error');
+		}
+	}
+
+	renderZones() {
+		const zones = this.core.filterUciSections(this._fwCfg, 'zone');
+		this.core.renderTable('#zones-table', zones, 7, 'No zones configured', z => {
+			const dests = this.zoneForwardings(z.name)
+				.map(f => f.dest)
+				.filter(Boolean);
+			const label = dests.length
+				? `${this.core.escapeHtml(z.name || z.section)} &rArr; ${this.core.escapeHtml(dests.join(', '))}`
+				: this.core.escapeHtml(z.name || z.section);
+			const nets = this.toList(z.network).join(', ') || '---';
+			return `<tr>
+				<td>${label}</td>
+				<td>${this.renderPolicyBadge(z.input)}</td>
+				<td>${this.renderPolicyBadge(z.output)}</td>
+				<td>${this.renderPolicyBadge(z.forward)}</td>
+				<td>${this.core.renderStatusBadge(z.masq === '1', 'ON', 'OFF')}</td>
+				<td>${this.core.escapeHtml(nets)}</td>
+				<td>${this.core.renderActionButtons(z.section)}</td>
+			</tr>`;
+		});
+	}
+
+	async loadNetworkNames() {
+		this._networkNames = [];
+		try {
+			const [s, r] = await this.core.uciGet('network');
+			if (s === 0 && r?.values) {
+				this._networkNames = this.core
+					.filterUciSections(r.values, 'interface')
+					.map(i => i.section)
+					.filter(n => n !== 'loopback');
+			}
+		} catch {}
+	}
+
+	zoneNetworksCombo() {
+		if (!this._zoneNetworksCombo) {
+			this._zoneNetworksCombo = this.core.createCombobox('zone-networks-combo', {
+				placeholder: 'Select networks...'
+			});
+		}
+		return this._zoneNetworksCombo;
+	}
+
+	zoneForwardCombo() {
+		if (!this._zoneForwardCombo) {
+			this._zoneForwardCombo = this.core.createCombobox('zone-forward-combo', {
+				placeholder: 'Select destination zones...'
+			});
+		}
+		return this._zoneForwardCombo;
+	}
+
+	async editZone(id) {
+		const z = this._fwCfg?.[id];
+		if (!z) {
+			this.core.showToast('Failed to load zone config', 'error');
+			return;
+		}
+		document.getElementById('edit-zone-section').value = id;
+		document.getElementById('edit-zone-name').value = z.name || '';
+		document.getElementById('edit-zone-input').value = z.input || 'ACCEPT';
+		document.getElementById('edit-zone-output').value = z.output || 'ACCEPT';
+		document.getElementById('edit-zone-forward').value = z.forward || 'REJECT';
+		document.getElementById('edit-zone-masq').value = z.masq === '1' ? '1' : '0';
+		document.getElementById('edit-zone-mtu-fix').value = z.mtu_fix === '1' ? '1' : '0';
+		await this.loadNetworkNames();
+		this.zoneNetworksCombo().setOptions(this._networkNames);
+		this.zoneNetworksCombo().setSelected(this.toList(z.network));
+		this.zoneForwardCombo().setOptions(this.zoneNames(z.name));
+		this.zoneForwardCombo().setSelected(
+			this.zoneForwardings(z.name)
+				.map(f => f.dest)
+				.filter(Boolean)
+		);
+		this.core.openModal('zone-modal');
+	}
+
+	async saveZone() {
+		const section = document.getElementById('edit-zone-section').value;
+		const name = document.getElementById('edit-zone-name').value.trim();
+		if (!/^[a-zA-Z0-9_]{1,11}$/.test(name)) {
+			this.core.showToast('Zone name must be 1-11 alphanumeric or underscore characters', 'error');
+			return;
+		}
+		const networks = this.zoneNetworksCombo().getSelected();
+		const values = {
+			name,
+			input: document.getElementById('edit-zone-input').value,
+			output: document.getElementById('edit-zone-output').value,
+			forward: document.getElementById('edit-zone-forward').value,
+			masq: document.getElementById('edit-zone-masq').value,
+			mtu_fix: document.getElementById('edit-zone-mtu-fix').value
+		};
+		if (networks.length) values.network = networks;
+		const oldName = section ? this._fwCfg?.[section]?.name : null;
+		try {
+			let target = section;
+			if (!target) {
+				const [, res] = await this.core.uciAdd('firewall', 'zone');
+				target = res.section;
+			}
+			await this.core.uciSet('firewall', target, values);
+			if (!networks.length && this._fwCfg?.[target]?.network) {
+				await this.core.uciDelete('firewall', target, 'network');
+			}
+
+			const allForwardings = this.core.filterUciSections(this._fwCfg || {}, 'forwarding');
+			if (oldName && oldName !== name) {
+				for (const type of ['forwarding', 'rule', 'redirect', 'nat']) {
+					for (const ref of this.core.filterUciSections(this._fwCfg || {}, type)) {
+						const upd = {};
+						if (ref.src === oldName) upd.src = name;
+						if (ref.dest === oldName) upd.dest = name;
+						if (Object.keys(upd).length) await this.core.uciSet('firewall', ref.section, upd);
+					}
+				}
+			}
+
+			const desired = this.zoneForwardCombo().getSelected();
+			const current = allForwardings.filter(f => f.src === (oldName || name));
+			for (const f of current) {
+				if (!desired.includes(f.dest)) await this.core.uciDelete('firewall', f.section);
+			}
+			const existingDests = current.map(f => f.dest);
+			for (const dest of desired) {
+				if (existingDests.includes(dest)) continue;
+				const [, res] = await this.core.uciAdd('firewall', 'forwarding');
+				await this.core.uciSet('firewall', res.section, { src: name, dest });
+			}
+
+			await this.core.uciCommit('firewall');
+			this.core.closeModal('zone-modal');
+			this.core.showToast('Zone saved', 'success');
+			this.loadFirewall();
+		} catch {
+			this.core.showToast('Failed to save zone', 'error');
+		}
+	}
+
+	async deleteZone(id) {
+		const name = this._fwCfg?.[id]?.name;
+		if (!confirm(`Delete zone "${name || id}" and its forwardings?`)) return;
+		try {
+			const stale = this.core
+				.filterUciSections(this._fwCfg || {}, 'forwarding')
+				.filter(f => f.src === name || f.dest === name);
+			for (const f of stale) await this.core.uciDelete('firewall', f.section);
+			await this.core.uciDelete('firewall', id);
+			await this.core.uciCommit('firewall');
+			this.core.showToast('Zone deleted', 'success');
+			this.loadFirewall();
+		} catch {
+			this.core.showToast('Failed to delete zone', 'error');
+		}
+	}
+
+	renderNatRules() {
+		const rules = this.core.filterUciSections(this._fwCfg, 'nat');
+		this.core.renderTable(
+			'#nat-table',
+			rules,
+			7,
+			'No NAT rules configured',
+			r => `<tr>
+			<td>${this.core.escapeHtml(r.name || r.section)}</td>
+			<td>${this.core.escapeHtml(r.src || 'Any')}</td>
+			<td>${this.core.escapeHtml(r.proto || 'all')}</td>
+			<td>${this.core.renderBadge(r.target === 'ACCEPT' ? 'info' : 'success', r.target || 'MASQUERADE')}</td>
+			<td>${this.core.escapeHtml(r.snat_ip || '---')}</td>
+			<td>${this.core.renderStatusBadge(r.enabled !== '0')}</td>
+			<td>${this.core.renderActionButtons(r.section)}</td>
+		</tr>`
+		);
+	}
+
+	populateNatZoneSelect(selected) {
+		const sel = document.getElementById('edit-nat-src');
+		if (!sel) return;
+		const names = this.zoneNames();
+		if (selected && !names.includes(selected)) names.push(selected);
+		sel.innerHTML = names
+			.map(
+				n =>
+					`<option value="${this.core.escapeHtml(n)}"${n === selected ? ' selected' : ''}>${this.core.escapeHtml(n)}</option>`
+			)
+			.join('');
+	}
+
+	editNat(id) {
+		this.populateNatZoneSelect(this._fwCfg?.[id]?.src || '');
+		this.core.uciEdit('firewall', id, NAT_FIELDS, 'nat-modal', 'edit-nat-section');
+	}
+
+	saveNat() {
+		const target = document.getElementById('edit-nat-target').value;
+		const snatIp = document.getElementById('edit-nat-snat-ip').value.trim();
+		if (target === 'SNAT' && !snatIp) {
+			this.core.showToast('SNAT requires a rewrite IP address', 'error');
+			return;
+		}
+		this.core.uciSave({
+			config: 'firewall',
+			uciType: 'nat',
+			modalId: 'nat-modal',
+			sectionIdField: 'edit-nat-section',
+			fieldMap: NAT_FIELDS,
+			reloadFn: () => this.loadFirewall(),
+			successMsg: 'NAT rule saved'
+		});
+	}
+
+	deleteNat(id) {
+		this.core.uciDeleteEntry('firewall', id, 'Delete this NAT rule?', () => this.loadFirewall());
 	}
 
 	async loadDHCP() {


### PR DESCRIPTION
Closes #28. Replaces #53, which GitHub auto-closed when its stacked base branch (`feat/devices-vlans`, #48) merged and was deleted; content and verification notes are identical to #53.

Adds the missing luci-app-firewall parity pieces to the Network > Firewall tab:

- **General settings** (`config defaults`): SYN flood protection, drop invalid packets, and the default input/output/forward policies, with a save action that creates the defaults section if absent.
- **Zones** (`config zone`): table showing each zone's policies, masquerade state, covered networks, and inter-zone forwardings (rendered as `src => dest` in the zone column). The editor covers name, per-direction policies, masquerade, MSS clamping, covered networks (combobox fed from `uci network` interface sections), and allowed forward-to zones. Saving reconciles `config forwarding` sections and a zone rename sweeps `forwarding`, `rule`, `redirect`, and `nat` sections so references stay valid. Deleting a zone also deletes its forwardings.
- **NAT rules** (`config nat`): table plus editor for name, source zone, protocol, MASQUERADE/SNAT/ACCEPT action, source/destination CIDRs, SNAT rewrite IP/port, and enabled state. SNAT requires a rewrite IP client-side.

No ACL changes needed; the existing `uci` firewall grants cover all calls.

Verified on an OpenWrt 24.10 armsr/armv8 QEMU VM through the lighttpd `/ubus` CGI bridge: zone create with networks and forwardings, rename with reference sweep, covered-network clearing, NAT rule create, zone and NAT delete flows, and `fw4 check` passes on the resulting config. Also exercised the rendered UI in a browser: zone editor round-trip and NAT rule creation via the modals.