### PR TITLE
Network parity: routes, DHCP/DNS settings, diagnostics, standalone ACLs

### DIFF
--- a/files/rpcd-moci
+++ b/files/rpcd-moci
@@ -9,10 +9,25 @@ clean_token() {
 
 case "$1" in
 	list)
-		printf '{ "setPassword": { "username": "str", "password": "str" }, "getDHCPLeases": { }, "getPorts": { }, "getBridges": { } }\n'
+		printf '{ "setPassword": { "username": "str", "password": "str" }, "getDHCPLeases": { }, "getPorts": { }, "getBridges": { }, "wgGenKey": { } }\n'
 		;;
 	call)
 		case "$2" in
+			wgGenKey)
+				if [ ! -x /usr/bin/wg ]; then
+					printf '{ "error": "wireguard-tools not installed" }\n'
+					exit 0
+				fi
+				priv=$(/usr/bin/wg genkey 2>/dev/null)
+				case "$priv" in
+					*[!A-Za-z0-9+/=]*|'') printf '{ "error": "key generation failed" }\n'; exit 0 ;;
+				esac
+				pub=$(printf '%s' "$priv" | /usr/bin/wg pubkey 2>/dev/null)
+				case "$pub" in
+					*[!A-Za-z0-9+/=]*|'') printf '{ "error": "key generation failed" }\n'; exit 0 ;;
+				esac
+				printf '{ "private_key": "%s", "public_key": "%s" }\n' "$priv" "$pub"
+				;;
 			getBridges)
 				out=''
 				for b in /sys/class/net/*; do

--- a/files/ubus-acl-moci.json
+++ b/files/ubus-acl-moci.json
@@ -8,7 +8,7 @@
 		"network.wireless": { "methods": [ "status" ] },
 		"uci": { "methods": [ "get", "set", "add", "delete", "commit" ] },
 		"file": { "methods": [ "read", "write", "exec" ] },
-		"moci": { "methods": [ "setPassword", "getDHCPLeases", "getPorts", "getBridges" ] },
+		"moci": { "methods": [ "setPassword", "getDHCPLeases", "getPorts", "getBridges", "wgGenKey" ] },
 		"service": { "methods": [ "list" ] }
 	}
 }

--- a/moci/index.html
+++ b/moci/index.html
@@ -190,6 +190,7 @@
 						<div class="tabs">
 							<button class="tab-btn active" data-tab="interfaces">INTERFACES</button>
 							<button class="tab-btn" data-tab="devices">DEVICES</button>
+							<button class="tab-btn" data-tab="routes">ROUTES</button>
 							<button class="tab-btn" data-tab="wireless">WIRELESS</button>
 							<button class="tab-btn" data-tab="firewall">FIREWALL</button>
 							<button class="tab-btn" data-tab="dhcp" data-feature="dhcp">DHCP</button>
@@ -342,6 +343,143 @@
 								<div class="modal-footer">
 									<button class="action-btn" id="cancel-bridge-vlan-btn">CANCEL</button>
 									<button class="action-btn" id="save-bridge-vlan-btn">SAVE CHANGES</button>
+								</div>
+							</div>
+						</div>
+
+						<div class="modal hidden" id="route-modal">
+							<div class="modal-backdrop"></div>
+							<div class="modal-content">
+								<div class="modal-header">
+									<h3 class="modal-title">STATIC ROUTE</h3>
+									<button class="modal-close" id="close-route-modal">&times;</button>
+								</div>
+								<div class="modal-body">
+									<input type="hidden" id="edit-route-section" />
+									<input type="hidden" id="edit-route-family" />
+									<div class="form-group">
+										<label class="form-label">INTERFACE</label>
+										<select id="edit-route-iface" class="form-input"></select>
+									</div>
+									<div class="form-group">
+										<label class="form-label">TARGET</label>
+										<input
+											type="text"
+											id="edit-route-target"
+											class="form-input"
+											placeholder="192.168.10.0/24 or host IP"
+										/>
+									</div>
+									<div class="form-group" id="route-netmask-group">
+										<label class="form-label">NETMASK (OPTIONAL)</label>
+										<input
+											type="text"
+											id="edit-route-netmask"
+											class="form-input"
+											placeholder="255.255.255.0"
+										/>
+									</div>
+									<div class="form-group">
+										<label class="form-label">GATEWAY</label>
+										<input
+											type="text"
+											id="edit-route-gateway"
+											class="form-input"
+											placeholder="192.168.1.1"
+										/>
+									</div>
+									<div class="form-group">
+										<label class="form-label">METRIC (OPTIONAL)</label>
+										<input type="text" id="edit-route-metric" class="form-input" placeholder="0" />
+									</div>
+									<div class="form-group">
+										<label class="form-label">MTU (OPTIONAL)</label>
+										<input type="text" id="edit-route-mtu" class="form-input" placeholder="1500" />
+									</div>
+									<div class="form-group">
+										<label class="form-label">TYPE</label>
+										<select id="edit-route-type" class="form-input">
+											<option value="unicast">unicast</option>
+											<option value="local">local</option>
+											<option value="broadcast">broadcast</option>
+											<option value="multicast">multicast</option>
+											<option value="unreachable">unreachable</option>
+											<option value="prohibit">prohibit</option>
+											<option value="blackhole">blackhole</option>
+											<option value="anycast">anycast</option>
+										</select>
+									</div>
+								</div>
+								<div class="modal-footer">
+									<button class="action-btn" id="cancel-route-btn">CANCEL</button>
+									<button class="action-btn" id="save-route-btn">SAVE CHANGES</button>
+								</div>
+							</div>
+						</div>
+
+						<div class="modal hidden" id="dhcp-pool-modal">
+							<div class="modal-backdrop"></div>
+							<div class="modal-content">
+								<div class="modal-header">
+									<h3 class="modal-title">DHCP POOL</h3>
+									<button class="modal-close" id="close-dhcp-pool-modal">&times;</button>
+								</div>
+								<div class="modal-body">
+									<input type="hidden" id="edit-pool-section" />
+									<div class="form-group">
+										<label class="form-label">POOL NAME</label>
+										<input type="text" id="edit-pool-name" class="form-input" placeholder="lan" />
+									</div>
+									<div class="form-group">
+										<label class="form-label">INTERFACE</label>
+										<select id="edit-pool-interface" class="form-input"></select>
+									</div>
+									<div class="form-group">
+										<label class="form-label">START ADDRESS OFFSET</label>
+										<input type="text" id="edit-pool-start" class="form-input" placeholder="100" />
+									</div>
+									<div class="form-group">
+										<label class="form-label">ADDRESS LIMIT</label>
+										<input type="text" id="edit-pool-limit" class="form-input" placeholder="150" />
+									</div>
+									<div class="form-group">
+										<label class="form-label">LEASE TIME</label>
+										<input
+											type="text"
+											id="edit-pool-leasetime"
+											class="form-input"
+											placeholder="12h"
+										/>
+									</div>
+									<div class="form-group">
+										<label class="form-label">IGNORE POOL</label>
+										<select id="edit-pool-ignore" class="form-input">
+											<option value="0">No (pool active)</option>
+											<option value="1">Yes (DHCP disabled)</option>
+										</select>
+									</div>
+									<div class="form-group">
+										<label class="form-label">DHCPV6 MODE</label>
+										<select id="edit-pool-dhcpv6" class="form-input">
+											<option value="">Not set</option>
+											<option value="server">server</option>
+											<option value="relay">relay</option>
+											<option value="disabled">disabled</option>
+										</select>
+									</div>
+									<div class="form-group">
+										<label class="form-label">ROUTER ADVERTISEMENT</label>
+										<select id="edit-pool-ra" class="form-input">
+											<option value="">Not set</option>
+											<option value="server">server</option>
+											<option value="relay">relay</option>
+											<option value="disabled">disabled</option>
+										</select>
+									</div>
+								</div>
+								<div class="modal-footer">
+									<button class="action-btn" id="cancel-dhcp-pool-btn">CANCEL</button>
+									<button class="action-btn" id="save-dhcp-pool-btn">SAVE CHANGES</button>
 								</div>
 							</div>
 						</div>
@@ -991,6 +1129,59 @@
 							</div>
 						</div>
 
+						<div class="tab-content hidden" id="tab-routes">
+							<div class="stat-card">
+								<div class="section-title">IPV4 STATIC ROUTES</div>
+								<button class="action-btn" id="add-route-btn" style="margin-bottom: 16px">
+									ADD ROUTE
+								</button>
+								<table class="data-table" id="routes-table">
+									<thead>
+										<tr>
+											<th>TARGET</th>
+											<th>GATEWAY</th>
+											<th>INTERFACE</th>
+											<th>METRIC</th>
+											<th>TYPE</th>
+											<th>ACTIONS</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td colspan="6" style="text-align: center; color: var(--steel-muted)">
+												Loading...
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+							<div class="stat-card" style="margin-top: 24px">
+								<div class="section-title">IPV6 STATIC ROUTES</div>
+								<button class="action-btn" id="add-route6-btn" style="margin-bottom: 16px">
+									ADD ROUTE
+								</button>
+								<table class="data-table" id="routes6-table">
+									<thead>
+										<tr>
+											<th>TARGET</th>
+											<th>GATEWAY</th>
+											<th>INTERFACE</th>
+											<th>METRIC</th>
+											<th>TYPE</th>
+											<th>ACTIONS</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td colspan="6" style="text-align: center; color: var(--steel-muted)">
+												Loading...
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+						</div>
+
 						<div class="tab-content hidden" id="tab-dhcp" data-feature="dhcp">
 							<div class="stat-card">
 								<div class="section-title">DHCP LEASES</div>
@@ -1036,10 +1227,80 @@
 									</tbody>
 								</table>
 							</div>
+
+							<div class="stat-card" style="margin-top: 24px">
+								<div class="section-title">DHCP POOLS</div>
+								<button class="action-btn" id="add-dhcp-pool-btn" style="margin-bottom: 16px">
+									ADD POOL
+								</button>
+								<table class="data-table" id="dhcp-pools-table">
+									<thead>
+										<tr>
+											<th>POOL</th>
+											<th>INTERFACE</th>
+											<th>START</th>
+											<th>LIMIT</th>
+											<th>LEASE TIME</th>
+											<th>STATUS</th>
+											<th>ACTIONS</th>
+										</tr>
+									</thead>
+									<tbody>
+										<tr>
+											<td colspan="7" style="text-align: center; color: var(--steel-muted)">
+												Loading...
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
 						</div>
 
 						<div class="tab-content hidden" id="tab-dns">
 							<div class="stat-card">
+								<div class="section-title">DNS SERVER SETTINGS</div>
+								<div class="form-group">
+									<label class="form-label">AUTHORITATIVE DHCP/DNS</label>
+									<select id="dns-authoritative" class="form-input">
+										<option value="1">Yes</option>
+										<option value="0">No</option>
+									</select>
+								</div>
+								<div class="form-group">
+									<label class="form-label">LOCAL DOMAIN</label>
+									<input type="text" id="dns-domain" class="form-input" placeholder="lan" />
+								</div>
+								<div class="form-group">
+									<label class="form-label">LOCAL SERVER</label>
+									<input type="text" id="dns-local" class="form-input" placeholder="/lan/" />
+								</div>
+								<div class="form-group">
+									<label class="form-label">DNS REBIND PROTECTION</label>
+									<select id="dns-rebind" class="form-input">
+										<option value="1">Enabled</option>
+										<option value="0">Disabled</option>
+									</select>
+								</div>
+								<div class="form-group">
+									<label class="form-label">LOG DNS QUERIES</label>
+									<select id="dns-logqueries" class="form-input">
+										<option value="0">Disabled</option>
+										<option value="1">Enabled</option>
+									</select>
+								</div>
+								<div class="form-group">
+									<label class="form-label">UPSTREAM DNS SERVERS</label>
+									<input
+										type="text"
+										id="dns-servers"
+										class="form-input"
+										placeholder="8.8.8.8 1.1.1.1 (space separated)"
+									/>
+								</div>
+								<button class="action-btn" id="save-dns-config-btn">SAVE SETTINGS</button>
+							</div>
+
+							<div class="stat-card" style="margin-top: 24px">
 								<div class="section-title">CUSTOM DNS ENTRIES</div>
 								<button class="action-btn" id="add-dns-entry-btn" style="margin-bottom: 16px">
 									ADD DNS ENTRY
@@ -1675,6 +1936,10 @@
 										placeholder="Enter hostname or IP"
 										class="diag-input"
 									/>
+									<select id="ping-family" class="form-input" style="max-width: 110px">
+										<option value="">IPv4</option>
+										<option value="6">IPv6</option>
+									</select>
 									<button class="action-btn" id="ping-btn">RUN PING</button>
 								</div>
 								<div class="log-viewer" id="ping-output" style="min-height: 200px">
@@ -1693,11 +1958,33 @@
 										placeholder="Enter hostname or IP"
 										class="diag-input"
 									/>
+									<select id="traceroute-family" class="form-input" style="max-width: 110px">
+										<option value="">IPv4</option>
+										<option value="6">IPv6</option>
+									</select>
 									<button class="action-btn" id="traceroute-btn">RUN TRACEROUTE</button>
 								</div>
 								<div class="log-viewer" id="traceroute-output" style="min-height: 200px">
 									<div class="log-line" style="color: var(--steel-muted)">
 										Enter a hostname or IP address and click Run Traceroute
+									</div>
+								</div>
+							</div>
+
+							<div class="stat-card" style="margin-top: 24px">
+								<div class="section-title">NSLOOKUP</div>
+								<div class="diagnostic-form">
+									<input
+										type="text"
+										id="nslookup-host"
+										placeholder="Enter hostname or IP"
+										class="diag-input"
+									/>
+									<button class="action-btn" id="nslookup-btn">RUN NSLOOKUP</button>
+								</div>
+								<div class="log-viewer" id="nslookup-output" style="min-height: 200px">
+									<div class="log-line" style="color: var(--steel-muted)">
+										Enter a hostname or IP address and click Run Nslookup
 									</div>
 								</div>
 							</div>

--- a/moci/js/modules/network.js
+++ b/moci/js/modules/network.js
@@ -1675,44 +1675,19 @@ export default class NetworkModule {
 	}
 
 	async generateWgKeys() {
-		let wroteKeyFile = false;
 		try {
-			const [s, r] = await this.core.ubusCall('file', 'exec', {
-				command: '/usr/bin/wg',
-				params: ['genkey']
-			});
-			if (s !== 0 || !r?.stdout) throw new Error('Key generation failed');
-			const privateKey = r.stdout.trim();
-			if (!/^[A-Za-z0-9+/]{43}=$/.test(privateKey)) {
+			const [s, r] = await this.core.ubusCall('moci', 'wgGenKey', {});
+			if (s !== 0 || !r?.private_key) throw new Error(r?.error || 'Key generation failed');
+			if (!/^[A-Za-z0-9+/]{43}=$/.test(r.private_key)) {
 				throw new Error('Invalid key format');
 			}
-			document.getElementById('wg-private-key').value = privateKey;
-
-			await this.core.ubusCall('file', 'write', {
-				path: '/tmp/.wg_priv.key',
-				data: privateKey + '\n'
-			});
-			wroteKeyFile = true;
-
-			const [s2, r2] = await this.core.ubusCall('file', 'exec', {
-				command: '/bin/sh',
-				params: ['-c', 'cat /tmp/.wg_priv.key | /usr/bin/wg pubkey']
-			});
-			if (s2 === 0 && r2?.stdout) {
-				document.getElementById('wg-public-key').value = r2.stdout.trim();
+			document.getElementById('wg-private-key').value = r.private_key;
+			if (r.public_key) {
+				document.getElementById('wg-public-key').value = r.public_key;
 			}
 			this.core.showToast('Keys generated', 'success');
 		} catch {
 			this.core.showToast('Failed to generate keys', 'error');
-		} finally {
-			if (wroteKeyFile) {
-				try {
-					await this.core.ubusCall('file', 'exec', {
-						command: '/bin/rm',
-						params: ['-f', '/tmp/.wg_priv.key']
-					});
-				} catch {}
-			}
 		}
 	}
 

--- a/moci/js/modules/network.js
+++ b/moci/js/modules/network.js
@@ -73,6 +73,7 @@ export default class NetworkModule {
 				const loadHandlers = {
 					interfaces: () => this.loadInterfaces(),
 					devices: () => this.loadDevices(),
+					routes: () => this.loadRoutes(),
 					wireless: () => this.loadWireless(),
 					firewall: () => this.loadFirewall(),
 					dhcp: () => this.loadDHCP(),
@@ -104,6 +105,8 @@ export default class NetworkModule {
 			{ prefix: 'fw-rule', save: () => this.saveFirewallRule() },
 			{ prefix: 'zone', save: () => this.saveZone() },
 			{ prefix: 'nat', save: () => this.saveNat() },
+			{ prefix: 'route', save: () => this.saveRoute() },
+			{ prefix: 'dhcp-pool', save: () => this.saveDhcpPool() },
 			{ prefix: 'static-lease', save: () => this.saveStaticLease() },
 			{ prefix: 'dns-entry', save: () => this.saveDnsEntry() },
 			{ prefix: 'host-entry', save: () => this.saveHostEntry() },
@@ -138,6 +141,19 @@ export default class NetworkModule {
 				this.core.resetModal(modalId);
 				this.core.openModal(modalId);
 			});
+		});
+
+		document.getElementById('add-route-btn')?.addEventListener('click', () => this.openRouteModal('route'));
+		document.getElementById('add-route6-btn')?.addEventListener('click', () => this.openRouteModal('route6'));
+
+		document.getElementById('add-dhcp-pool-btn')?.addEventListener('click', async () => {
+			this.core.resetModal('dhcp-pool-modal');
+			const nameInput = document.getElementById('edit-pool-name');
+			nameInput.disabled = false;
+			nameInput.value = '';
+			await this.loadNetworkNames();
+			this.populateIfaceSelect('edit-pool-interface', '');
+			this.core.openModal('dhcp-pool-modal');
 		});
 
 		document.getElementById('add-zone-btn')?.addEventListener('click', async () => {
@@ -186,6 +202,9 @@ export default class NetworkModule {
 			'fw-rules-table': { edit: id => this.editFirewallRule(id), delete: id => this.deleteFirewallRule(id) },
 			'zones-table': { edit: id => this.editZone(id), delete: id => this.deleteZone(id) },
 			'nat-table': { edit: id => this.editNat(id), delete: id => this.deleteNat(id) },
+			'routes-table': { edit: id => this.editRoute(id), delete: id => this.deleteRoute(id) },
+			'routes6-table': { edit: id => this.editRoute(id), delete: id => this.deleteRoute(id) },
+			'dhcp-pools-table': { edit: id => this.editDhcpPool(id), delete: id => this.deleteDhcpPool(id) },
 			'dhcp-static-table': { edit: id => this.editStaticLease(id), delete: id => this.deleteStaticLease(id) },
 			'dns-entries-table': { edit: id => this.editDnsEntry(id), delete: id => this.deleteDnsEntry(id) },
 			'hosts-table': { edit: id => this.editHostEntry(id), delete: id => this.deleteHostEntry(id) },
@@ -200,6 +219,7 @@ export default class NetworkModule {
 		}
 
 		document.getElementById('save-fw-defaults-btn')?.addEventListener('click', () => this.saveFwDefaults());
+		document.getElementById('save-dns-config-btn')?.addEventListener('click', () => this.saveDnsConfig());
 		document.getElementById('save-qos-config-btn')?.addEventListener('click', () => this.saveQoSConfig());
 		document.getElementById('save-wg-config-btn')?.addEventListener('click', () => this.saveWgConfig());
 		document.getElementById('generate-wg-keys-btn')?.addEventListener('click', () => this.generateWgKeys());
@@ -209,6 +229,7 @@ export default class NetworkModule {
 		document.getElementById('ping-btn')?.addEventListener('click', () => this.runDiagnostic('ping'));
 		document.getElementById('traceroute-btn')?.addEventListener('click', () => this.runDiagnostic('traceroute'));
 		document.getElementById('wol-btn')?.addEventListener('click', () => this.runWoL());
+		document.getElementById('nslookup-btn')?.addEventListener('click', () => this.runDiagnostic('nslookup'));
 	}
 
 	cleanup() {
@@ -434,7 +455,6 @@ export default class NetworkModule {
 		}
 		const ports = this.devicePortsCombo().getSelected();
 		const values = { name, type: 'bridge' };
-		if (ports.length) values.ports = ports;
 		if (mtu) values.mtu = mtu;
 		const oldName = section ? this._netCfg?.[section]?.name : null;
 		try {
@@ -444,9 +464,7 @@ export default class NetworkModule {
 				target = res.section;
 			}
 			await this.core.uciSet('network', target, values);
-			if (!ports.length && this._netCfg?.[target]?.ports) {
-				await this.core.uciDelete('network', target, 'ports');
-			}
+			await this.setListOption('network', target, 'ports', ports, !!this._netCfg?.[target]?.ports);
 			if (oldName && oldName !== name) {
 				for (const v of this.core.filterUciSections(this._netCfg, 'bridge-vlan')) {
 					if (v.device === oldName) await this.core.uciSet('network', v.section, { device: name });
@@ -514,13 +532,11 @@ export default class NetworkModule {
 	populateVlanDeviceSelect(selected) {
 		const sel = document.getElementById('edit-bridge-vlan-device');
 		if (!sel) return;
-		const devices = this.bridgeDevices();
-		sel.innerHTML = devices
-			.map(
-				d =>
-					`<option value="${this.core.escapeHtml(d.name)}"${d.name === selected ? ' selected' : ''}>${this.core.escapeHtml(d.name)}</option>`
-			)
-			.join('');
+		this.populateSelect(
+			'edit-bridge-vlan-device',
+			this.bridgeDevices().map(d => d.name),
+			selected
+		);
 		sel.onchange = () => this.renderVlanPortGrid(sel.value);
 	}
 
@@ -572,6 +588,140 @@ export default class NetworkModule {
 
 	deleteBridgeVlan(id) {
 		this.core.uciDeleteEntry('network', id, 'Delete this bridge VLAN?', () => this.loadDevices());
+	}
+
+	populateSelect(id, names, selected) {
+		const sel = document.getElementById(id);
+		if (!sel) return;
+		sel.innerHTML = names
+			.map(
+				n =>
+					`<option value="${this.core.escapeHtml(n)}"${n === selected ? ' selected' : ''}>${this.core.escapeHtml(n)}</option>`
+			)
+			.join('');
+	}
+
+	populateIfaceSelect(id, selected) {
+		this.populateSelect(id, this._networkNames || [], selected);
+	}
+
+	async setListOption(config, section, option, list, hadValue) {
+		if (list.length) {
+			await this.core.uciSet(config, section, { [option]: list });
+		} else if (hadValue) {
+			await this.core.uciDelete(config, section, option);
+		}
+	}
+
+	async loadRoutes() {
+		await this.core.loadResource('routes-table', 6, 'network', async () => {
+			const [status, result] = await this.core.uciGet('network');
+			if (status !== 0 || !result?.values) throw new Error('No data');
+			this._netCfg = result.values;
+			for (const [type, tableId] of [
+				['route', '#routes-table'],
+				['route6', '#routes6-table']
+			]) {
+				const routes = this.core.filterUciSections(this._netCfg, type);
+				this.core.renderTable(tableId, routes, 6, 'No static routes configured', r => {
+					const target = r.netmask ? `${r.target || '---'} / ${r.netmask}` : r.target || '---';
+					return `<tr>
+					<td>${this.core.escapeHtml(target)}</td>
+					<td>${this.core.escapeHtml(r.gateway || '---')}</td>
+					<td>${this.core.escapeHtml(r.interface || '---')}</td>
+					<td>${this.core.escapeHtml(r.metric || '0')}</td>
+					<td>${this.core.escapeHtml(r.type || 'unicast')}</td>
+					<td>${this.core.renderActionButtons(r.section)}</td>
+				</tr>`;
+				});
+			}
+		});
+	}
+
+	async openRouteModal(family) {
+		this.core.resetModal('route-modal');
+		document.getElementById('edit-route-family').value = family;
+		document.getElementById('route-netmask-group').style.display = family === 'route6' ? 'none' : '';
+		await this.loadNetworkNames();
+		this.populateIfaceSelect('edit-route-iface', '');
+		this.core.openModal('route-modal');
+	}
+
+	async editRoute(id) {
+		const r = this._netCfg?.[id];
+		if (!r) {
+			this.core.showToast('Failed to load route config', 'error');
+			return;
+		}
+		const family = r['.type'];
+		this.core.resetModal('route-modal');
+		document.getElementById('edit-route-section').value = id;
+		document.getElementById('edit-route-family').value = family;
+		document.getElementById('route-netmask-group').style.display = family === 'route6' ? 'none' : '';
+		await this.loadNetworkNames();
+		this.populateIfaceSelect('edit-route-iface', r.interface || '');
+		document.getElementById('edit-route-target').value = r.target || '';
+		document.getElementById('edit-route-netmask').value = r.netmask || '';
+		document.getElementById('edit-route-gateway').value = r.gateway || '';
+		document.getElementById('edit-route-metric').value = r.metric || '';
+		document.getElementById('edit-route-mtu').value = r.mtu || '';
+		document.getElementById('edit-route-type').value = r.type || 'unicast';
+		this.core.openModal('route-modal');
+	}
+
+	async saveRoute() {
+		const section = document.getElementById('edit-route-section').value;
+		const family = document.getElementById('edit-route-family').value || 'route';
+		const target = document.getElementById('edit-route-target').value.trim();
+		if (!target) {
+			this.core.showToast('Route target is required', 'error');
+			return;
+		}
+		const optionals = {
+			netmask: family === 'route6' ? '' : document.getElementById('edit-route-netmask').value.trim(),
+			gateway: document.getElementById('edit-route-gateway').value.trim(),
+			metric: document.getElementById('edit-route-metric').value.trim(),
+			mtu: document.getElementById('edit-route-mtu').value.trim()
+		};
+		for (const key of ['metric', 'mtu']) {
+			if (optionals[key] && !/^\d+$/.test(optionals[key])) {
+				this.core.showToast(`${key.toUpperCase()} must be a number`, 'error');
+				return;
+			}
+		}
+		const values = {
+			interface: document.getElementById('edit-route-iface').value,
+			target,
+			type: document.getElementById('edit-route-type').value
+		};
+		for (const [key, val] of Object.entries(optionals)) {
+			if (val) values[key] = val;
+		}
+		try {
+			let sectionTarget = section;
+			if (!sectionTarget) {
+				const [, res] = await this.core.uciAdd('network', family);
+				sectionTarget = res.section;
+			}
+			await this.core.uciSet('network', sectionTarget, values);
+			if (section) {
+				for (const [key, val] of Object.entries(optionals)) {
+					if (!val && this._netCfg?.[section]?.[key]) {
+						await this.core.uciDelete('network', section, key);
+					}
+				}
+			}
+			await this.core.uciCommit('network');
+			this.core.closeModal('route-modal');
+			this.core.showToast('Route saved', 'success');
+			this.loadRoutes();
+		} catch {
+			this.core.showToast('Failed to save route', 'error');
+		}
+	}
+
+	deleteRoute(id) {
+		this.core.uciDeleteEntry('network', id, 'Delete this static route?', () => this.loadRoutes());
 	}
 
 	async loadWireless() {
@@ -900,7 +1050,6 @@ export default class NetworkModule {
 			masq: document.getElementById('edit-zone-masq').value,
 			mtu_fix: document.getElementById('edit-zone-mtu-fix').value
 		};
-		if (networks.length) values.network = networks;
 		const oldName = section ? this._fwCfg?.[section]?.name : null;
 		try {
 			let target = section;
@@ -909,9 +1058,7 @@ export default class NetworkModule {
 				target = res.section;
 			}
 			await this.core.uciSet('firewall', target, values);
-			if (!networks.length && this._fwCfg?.[target]?.network) {
-				await this.core.uciDelete('firewall', target, 'network');
-			}
+			await this.setListOption('firewall', target, 'network', networks, !!this._fwCfg?.[target]?.network);
 
 			const allForwardings = this.core.filterUciSections(this._fwCfg || {}, 'forwarding');
 			if (oldName && oldName !== name) {
@@ -983,16 +1130,9 @@ export default class NetworkModule {
 	}
 
 	populateNatZoneSelect(selected) {
-		const sel = document.getElementById('edit-nat-src');
-		if (!sel) return;
 		const names = this.zoneNames();
 		if (selected && !names.includes(selected)) names.push(selected);
-		sel.innerHTML = names
-			.map(
-				n =>
-					`<option value="${this.core.escapeHtml(n)}"${n === selected ? ' selected' : ''}>${this.core.escapeHtml(n)}</option>`
-			)
-			.join('');
+		this.populateSelect('edit-nat-src', names, selected);
 	}
 
 	editNat(id) {
@@ -1045,6 +1185,24 @@ export default class NetworkModule {
 
 			const [status, result] = await this.core.uciGet('dhcp');
 			if (status !== 0 || !result?.values) return;
+			this._dhcpCfg = result.values;
+
+			const pools = this.core.filterUciSections(result.values, 'dhcp');
+			this.core.renderTable(
+				'#dhcp-pools-table',
+				pools,
+				7,
+				'No DHCP pools configured',
+				p => `<tr>
+				<td>${this.core.escapeHtml(p.section)}</td>
+				<td>${this.core.escapeHtml(p.interface || '---')}</td>
+				<td>${this.core.escapeHtml(p.start || '---')}</td>
+				<td>${this.core.escapeHtml(p.limit || '---')}</td>
+				<td>${this.core.escapeHtml(p.leasetime || '---')}</td>
+				<td>${this.core.renderStatusBadge(p.ignore !== '1', 'ACTIVE', 'IGNORED')}</td>
+				<td>${this.core.renderActionButtons(p.section)}</td>
+			</tr>`
+			);
 
 			const statics = this.core.filterUciSections(result.values, 'host');
 			this.core.renderTable(
@@ -1082,10 +1240,81 @@ export default class NetworkModule {
 		this.core.uciDeleteEntry('dhcp', id, 'Delete this static lease?', () => this.loadDHCP());
 	}
 
+	async editDhcpPool(id) {
+		const c = this._dhcpCfg?.[id];
+		if (!c) {
+			this.core.showToast('Failed to load pool config', 'error');
+			return;
+		}
+		this.core.resetModal('dhcp-pool-modal');
+		const nameInput = document.getElementById('edit-pool-name');
+		nameInput.value = id;
+		nameInput.disabled = true;
+		document.getElementById('edit-pool-section').value = id;
+		await this.loadNetworkNames();
+		this.populateIfaceSelect('edit-pool-interface', c.interface || '');
+		document.getElementById('edit-pool-start').value = c.start || '';
+		document.getElementById('edit-pool-limit').value = c.limit || '';
+		document.getElementById('edit-pool-leasetime').value = c.leasetime || '';
+		document.getElementById('edit-pool-ignore').value = c.ignore === '1' ? '1' : '0';
+		document.getElementById('edit-pool-dhcpv6').value = c.dhcpv6 || '';
+		document.getElementById('edit-pool-ra').value = c.ra || '';
+		this.core.openModal('dhcp-pool-modal');
+	}
+
+	async saveDhcpPool() {
+		const section = document.getElementById('edit-pool-section').value;
+		const optionals = {
+			start: document.getElementById('edit-pool-start').value.trim(),
+			limit: document.getElementById('edit-pool-limit').value.trim(),
+			leasetime: document.getElementById('edit-pool-leasetime').value.trim(),
+			dhcpv6: document.getElementById('edit-pool-dhcpv6').value,
+			ra: document.getElementById('edit-pool-ra').value
+		};
+		const values = {
+			interface: document.getElementById('edit-pool-interface').value,
+			ignore: document.getElementById('edit-pool-ignore').value
+		};
+		for (const [key, val] of Object.entries(optionals)) {
+			if (val) values[key] = val;
+		}
+		try {
+			let target = section;
+			if (!target) {
+				const name = document.getElementById('edit-pool-name').value.trim();
+				if (!/^[a-zA-Z0-9_]+$/.test(name)) {
+					this.core.showToast('Pool name must be alphanumeric or underscore', 'error');
+					return;
+				}
+				const [, res] = await this.core.uciAdd('dhcp', 'dhcp', name);
+				target = res?.section || name;
+			}
+			await this.core.uciSet('dhcp', target, values);
+			if (section) {
+				for (const [key, val] of Object.entries(optionals)) {
+					if (!val && this._dhcpCfg?.[section]?.[key]) {
+						await this.core.uciDelete('dhcp', section, key);
+					}
+				}
+			}
+			await this.core.uciCommit('dhcp');
+			this.core.closeModal('dhcp-pool-modal');
+			this.core.showToast('DHCP pool saved', 'success');
+			this.loadDHCP();
+		} catch {
+			this.core.showToast('Failed to save DHCP pool', 'error');
+		}
+	}
+
+	deleteDhcpPool(id) {
+		this.core.uciDeleteEntry('dhcp', id, `Delete DHCP pool "${id}"?`, () => this.loadDHCP());
+	}
+
 	async loadDNS() {
 		await this.core.loadResource('dns-entries-table', 3, 'dns', async () => {
 			const [status, result] = await this.core.uciGet('dhcp');
 			if (status === 0 && result?.values) {
+				this.renderDnsConfig(result.values);
 				const domains = this.core.filterUciSections(result.values, 'domain');
 				this.core.renderTable(
 					'#dns-entries-table',
@@ -1130,6 +1359,46 @@ export default class NetworkModule {
 				return { ip: parts[0], names: parts.slice(1).join(' ') };
 			})
 			.filter(e => e.ip && e.names);
+	}
+
+	renderDnsConfig(cfg) {
+		const dnsmasq = this.core.filterUciSections(cfg, 'dnsmasq')[0];
+		this._dnsmasqSection = dnsmasq?.section || null;
+		this._dnsmasqHadServers = !!dnsmasq?.server;
+		const el = id => document.getElementById(id);
+		el('dns-authoritative').value = dnsmasq?.authoritative === '0' ? '0' : '1';
+		el('dns-domain').value = dnsmasq?.domain || '';
+		el('dns-local').value = dnsmasq?.local || '';
+		el('dns-rebind').value = dnsmasq?.rebind_protection === '0' ? '0' : '1';
+		el('dns-logqueries').value = dnsmasq?.logqueries === '1' ? '1' : '0';
+		el('dns-servers').value = this.toList(dnsmasq?.server).join(' ');
+	}
+
+	async saveDnsConfig() {
+		const servers = document
+			.getElementById('dns-servers')
+			.value.split(/[\s,]+/)
+			.filter(Boolean);
+		try {
+			let target = this._dnsmasqSection;
+			if (!target) {
+				const [, res] = await this.core.uciAdd('dhcp', 'dnsmasq');
+				target = res.section;
+			}
+			await this.core.uciSet('dhcp', target, {
+				authoritative: document.getElementById('dns-authoritative').value,
+				domain: document.getElementById('dns-domain').value.trim(),
+				local: document.getElementById('dns-local').value.trim(),
+				rebind_protection: document.getElementById('dns-rebind').value,
+				logqueries: document.getElementById('dns-logqueries').value
+			});
+			await this.setListOption('dhcp', target, 'server', servers, this._dnsmasqHadServers);
+			await this.core.uciCommit('dhcp');
+			this.core.showToast('DNS settings saved', 'success');
+			this.loadDNS();
+		} catch {
+			this.core.showToast('Failed to save DNS settings', 'error');
+		}
 	}
 
 	editDnsEntry(id) {
@@ -1533,9 +1802,14 @@ export default class NetworkModule {
 
 		output.innerHTML = '<div class="log-line">Running...</div>';
 
+		const family = document.getElementById(`${type}-family`)?.value || '';
 		const commands = {
-			ping: { command: '/bin/ping', params: ['-c', '5', '-W', '3', host] },
-			traceroute: { command: '/usr/bin/traceroute', params: ['-w', '3', '-m', '15', host] }
+			ping: { command: family ? '/bin/ping6' : '/bin/ping', params: ['-c', '5', '-W', '3', host] },
+			traceroute: {
+				command: family ? '/usr/bin/traceroute6' : '/usr/bin/traceroute',
+				params: ['-w', '3', '-m', '15', host]
+			},
+			nslookup: { command: '/usr/bin/nslookup', params: [host] }
 		};
 
 		try {

--- a/rpcd-acl.json
+++ b/rpcd-acl.json
@@ -24,7 +24,8 @@
 				"/bin/ping6": ["exec"],
 				"/usr/bin/traceroute": ["exec"],
 				"/usr/bin/traceroute6": ["exec"],
-				"/usr/bin/nslookup": ["exec"]
+				"/usr/bin/nslookup": ["exec"],
+				"/bin/df -h": ["exec"]
 			},
 			"ubus": {
 				"network.interface": ["dump"],
@@ -44,14 +45,28 @@
 				"/usr/libexec/moci-pkg-call update": ["exec"],
 				"/usr/libexec/moci-pkg-call feed-add *": ["exec"],
 				"/usr/libexec/moci-pkg-call feed-remove *": ["exec"],
-				"/usr/bin/etherwake": ["exec"]
+				"/usr/bin/etherwake": ["exec"],
+				"/etc/hosts": ["write"],
+				"/etc/crontabs/root": ["write"],
+				"/etc/dropbear/authorized_keys": ["write"],
+				"/tmp/firmware.bin": ["write"],
+				"/etc/init.d/* reload": ["exec"],
+				"/etc/init.d/* start": ["exec"],
+				"/etc/init.d/* stop": ["exec"],
+				"/sbin/sysupgrade --create-backup /tmp/backup.tar.gz": ["exec"],
+				"/sbin/sysupgrade --test /tmp/firmware.bin": ["exec"],
+				"/sbin/sysupgrade /tmp/firmware.bin": ["exec"],
+				"/sbin/sysupgrade -n /tmp/firmware.bin": ["exec"],
+				"/sbin/firstboot -y": ["exec"],
+				"/bin/rm -f /tmp/backup.tar.gz": ["exec"],
+				"/bin/rm -f /tmp/firmware.bin": ["exec"]
 			},
 			"ubus": {
 				"uci": ["set", "add", "delete", "commit"],
 				"file": ["write", "exec"],
 				"system": ["reboot"],
 				"network.interface": ["up", "down"],
-				"moci": ["setPassword"]
+				"moci": ["setPassword", "wgGenKey"]
 			},
 			"uci": [
 				"network",

--- a/rpcd-acl.json
+++ b/rpcd-acl.json
@@ -19,7 +19,12 @@
 				"/usr/libexec/moci-pkg-call inspect *": ["exec"],
 				"/usr/libexec/moci-pkg-call feeds": ["exec"],
 				"/sbin/logread": ["exec"],
-				"/bin/dmesg": ["exec"]
+				"/bin/dmesg": ["exec"],
+				"/bin/ping": ["exec"],
+				"/bin/ping6": ["exec"],
+				"/usr/bin/traceroute": ["exec"],
+				"/usr/bin/traceroute6": ["exec"],
+				"/usr/bin/nslookup": ["exec"]
 			},
 			"ubus": {
 				"network.interface": ["dump"],
@@ -38,7 +43,8 @@
 				"/usr/libexec/moci-pkg-call remove *": ["exec"],
 				"/usr/libexec/moci-pkg-call update": ["exec"],
 				"/usr/libexec/moci-pkg-call feed-add *": ["exec"],
-				"/usr/libexec/moci-pkg-call feed-remove *": ["exec"]
+				"/usr/libexec/moci-pkg-call feed-remove *": ["exec"],
+				"/usr/bin/etherwake": ["exec"]
 			},
 			"ubus": {
 				"uci": ["set", "add", "delete", "commit"],


### PR DESCRIPTION
Closes #29, closes #30, closes #31, closes #55.

Four tracking items built together since they share the Network page surface and the ACL file:

**Static routes (#30)**: new ROUTES sub-tab with separate IPv4 (`config route`) and IPv6 (`config route6`) tables and a shared editor covering interface, target, netmask (IPv4 only, hidden for IPv6), gateway, metric, MTU, and route type. Clearing an optional field on edit deletes the uci option rather than writing an empty value; metric and MTU are validated numeric.

**DHCP pools and DNS server settings (#29)**: the DHCP tab gains a pools table (`config dhcp` named sections) with an editor for interface, start/limit/leasetime, ignore, and DHCPv6/RA modes; new pools are created as named sections. The DNS tab gains a `config dnsmasq` settings card: authoritative mode, local domain/server, rebind protection, query logging, and the upstream `server` list (cleared list deletes the option).

**Diagnostics (#31)**: ping and traceroute get an IPv4/IPv6 selector (`/bin/ping6`, `/usr/bin/traceroute6`), and a new nslookup card reuses the same run-and-render path. Output is run-and-dump rather than streamed since the ubus CGI bridge is request/response.

**Standalone ACLs (#55)**: every `file` read/write/exec the frontend performs is now covered by MoCI's own rpcd ACL group instead of riding on LuCI's groups being installed:
- exec grants for ping/ping6/traceroute/traceroute6/nslookup (diagnostics), etherwake (WoL), `df -h` (storage), `/etc/init.d/* reload|start|stop` (service controls), the exact sysupgrade backup/test/flash invocations, firstboot, and the two temp-file cleanups
- write grants for `/etc/hosts`, `/etc/crontabs/root`, `/etc/dropbear/authorized_keys`, and `/tmp/firmware.bin`
- WireGuard key generation moves into `files/rpcd-moci` as a native `wgGenKey` ubus method (returns the keypair, degrades gracefully when wireguard-tools is absent). The old frontend flow needed an un-grantable `/bin/sh -c` exec and wrote the private key to a world-readable path in `/tmp`; both are gone.

DRY refactors folded in per review goals: a shared `populateSelect` helper replaces the hand-rolled option builders in the NAT zone and VLAN device selects (and serves the new route/pool interface selects), and a shared `setListOption` helper replaces the duplicated set-or-delete list logic in `saveDevice` (ports) and `saveZone` (networks) and serves the dnsmasq server list.

Verified on the OpenWrt 24.10 QEMU VM through the lighttpd `/ubus` bridge, including a standalone proof: with all `luci-*` rpcd ACL groups removed from the device and only MoCI's groups loaded, the full battery passes (uci get, hosts/crontab/dropbear writes, ping/nslookup/logread/df execs, init.d reload/start/stop, sysupgrade backup create/read/cleanup, and `wgGenKey` returning a valid keypair with wireguard-tools installed), while ungranted execs and writes remain denied. UI exercised in a browser: route created via the modal, pools and DNS cards render live config, nslookup resolves and renders. traceroute/traceroute6 are not present on the minimal test image (pre-existing situation); paths match the packaged binaries.